### PR TITLE
Added Resource Templates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import {
   checkImportStatus,
   checkImportStatusSchema,
 } from "./tools/check_import_status.js";
-import {memoryByName} from "./tools/memory_by_name.js";
+import {getMemoryByName} from "./tools/get_memory_by_name.js";
 
 const LARA_ACCESS_KEY_ID = process.env.LARA_ACCESS_KEY_ID;
 const LARA_ACCESS_KEY_SECRET = process.env.LARA_ACCESS_KEY_SECRET;
@@ -229,9 +229,9 @@ server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
     return {
         resourceTemplates: [
         {
-            name: "Memory by Name",
+            name: "Get Memory by Name",
             uriTemplate: "memories://list/{name}",
-            description: "Check if a memory exists from its name",
+            description: "Returns a memory by its name",
         }
         ]
     };
@@ -271,7 +271,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
             };
         }
 
-        const memory = await memoryByName(lara, name);
+        const memory = await getMemoryByName(lara, name);
         if (!memory) {
           return {
             contents: [{

--- a/src/tools/get_memory_by_name.ts
+++ b/src/tools/get_memory_by_name.ts
@@ -1,7 +1,7 @@
 import {Translator} from "@translated/lara";
 import {listMemories} from "./list_memories.js";
 
-export async function memoryByName(lara: Translator, name: string): Promise<any> {
+export async function getMemoryByName(lara: Translator, name: string): Promise<any> {
     const memories = await listMemories(lara);
     return memories.find(m => m.name === name);
 }

--- a/src/tools/memory_by_name.ts
+++ b/src/tools/memory_by_name.ts
@@ -1,0 +1,7 @@
+import {Translator} from "@translated/lara";
+import {listMemories} from "./list_memories.js";
+
+export async function memoryByName(lara: Translator, name: string): Promise<any> {
+    const memories = await listMemories(lara);
+    return memories.find(m => m.name === name);
+}


### PR DESCRIPTION
# Resource Templates
### ### 
This pull request introduces resource templates to Lara MCP.


## Feature Support 
Resource templates are not currently supported by any published client, not even by anthropic's Claude. 

One client introduced partial support for resource templates very recently. 

This client returns error when the feature is missing - this explains why in this [issue](https://github.com/translated/lara-mcp/issues/8) the user's MCP server was working correctly, but an error kept showing up after the latest versions of the client used introduced support for resource templates.

## How does it work? 

### Accessing dynamic resources
- Resource templates allow clients to access resources dynamically. 
The URI is not fixed as regular resources - it is now called uriTemplate and it contains additional custom parameters.