### PR TITLE
feat: add style, reasoning, and content_type options to translate tool

### DIFF
--- a/src/__tests__/tools/translate.test.ts
+++ b/src/__tests__/tools/translate.test.ts
@@ -121,6 +121,58 @@ describe('translateSchema', () => {
       glossaries: ['invalid-id']
     })).toThrow();
   });
+
+  it('should accept valid style values', () => {
+    for (const style of ['faithful', 'fluid', 'creative']) {
+      expect(() => translateSchema.parse({
+        text: [{ text: 'hello', translatable: true }],
+        target: 'it-IT',
+        style
+      })).not.toThrow();
+    }
+  });
+
+  it('should reject invalid style value', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      style: 'invalid'
+    })).toThrow();
+  });
+
+  it('should accept reasoning boolean', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      reasoning: true
+    })).not.toThrow();
+  });
+
+  it('should reject non-boolean reasoning', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      reasoning: 'yes'
+    })).toThrow();
+  });
+
+  it('should accept valid content_type values', () => {
+    for (const content_type of ['text/plain', 'text/html', 'application/xliff+xml']) {
+      expect(() => translateSchema.parse({
+        text: [{ text: 'hello', translatable: true }],
+        target: 'it-IT',
+        content_type
+      })).not.toThrow();
+    }
+  });
+
+  it('should reject invalid content_type value', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      content_type: 'application/json'
+    })).toThrow();
+  });
 });
 
 describe('translateHandler', () => {
@@ -251,6 +303,94 @@ describe('translateHandler', () => {
       expect.objectContaining({
         priority: 'background',
         timeoutInMillis: 60000
+      })
+    );
+  });
+
+  it('should pass style option to SDK', async () => {
+    mockTranslator.translate.mockResolvedValue({
+      translation: [{ text: 'ciao', translatable: true }]
+    });
+
+    await translateHandler({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      style: 'creative'
+    }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.translate).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      'it-IT',
+      expect.objectContaining({
+        style: 'creative'
+      })
+    );
+  });
+
+  it('should pass reasoning option to SDK', async () => {
+    mockTranslator.translate.mockResolvedValue({
+      translation: [{ text: 'ciao', translatable: true }]
+    });
+
+    await translateHandler({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      reasoning: true
+    }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.translate).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      'it-IT',
+      expect.objectContaining({
+        reasoning: true
+      })
+    );
+  });
+
+  it('should pass content_type as contentType to SDK', async () => {
+    mockTranslator.translate.mockResolvedValue({
+      translation: [{ text: 'ciao', translatable: true }]
+    });
+
+    await translateHandler({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      content_type: 'text/html'
+    }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.translate).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      'it-IT',
+      expect.objectContaining({
+        contentType: 'text/html'
+      })
+    );
+  });
+
+  it('should pass style, reasoning, and content_type together', async () => {
+    mockTranslator.translate.mockResolvedValue({
+      translation: [{ text: 'ciao', translatable: true }]
+    });
+
+    await translateHandler({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      style: 'fluid',
+      reasoning: true,
+      content_type: 'application/xliff+xml'
+    }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.translate).toHaveBeenCalledWith(
+      expect.anything(),
+      null,
+      'it-IT',
+      expect.objectContaining({
+        style: 'fluid',
+        reasoning: true,
+        contentType: 'application/xliff+xml'
       })
     );
   });

--- a/src/mcp/tools/translate.ts
+++ b/src/mcp/tools/translate.ts
@@ -85,7 +85,7 @@ export const translateSchema = z.object({
     .enum(["faithful", "fluid", "creative"])
     .optional()
     .describe(
-      "Controls how the translation balances accuracy against natural readability. 'faithful' (default) stays close to the source, 'fluid' prioritizes natural readability, 'creative' allows more freedom in the translation."
+      "Controls how the translation balances accuracy against natural readability. 'faithful' stays close to the source, 'fluid' prioritizes natural readability, 'creative' allows more freedom in the translation."
     ),
   reasoning: z
     .boolean()

--- a/src/mcp/tools/translate.ts
+++ b/src/mcp/tools/translate.ts
@@ -81,6 +81,24 @@ export const translateSchema = z.object({
     .describe(
       "Custom timeout for the translation request in milliseconds. Max: 300000ms (5 minutes). Useful for very long texts."
     ),
+  style: z
+    .enum(["faithful", "fluid", "creative"])
+    .optional()
+    .describe(
+      "Controls how the translation balances accuracy against natural readability. 'faithful' (default) stays close to the source, 'fluid' prioritizes natural readability, 'creative' allows more freedom in the translation."
+    ),
+  reasoning: z
+    .boolean()
+    .optional()
+    .describe(
+      "Enables Lara Think multi-step linguistic analysis. Can increase processing time up to 10x but may improve translation quality for complex texts."
+    ),
+  content_type: z
+    .enum(["text/plain", "text/html", "application/xliff+xml"])
+    .optional()
+    .describe(
+      "Specifies the content type of the text. Autodetected if omitted."
+    ),
 });
 
 const makeInstructions = (text: string) =>
@@ -98,7 +116,10 @@ export async function translateHandler(args: unknown, lara: Translator) {
     glossaries,
     no_trace,
     priority,
-    timeout_in_millis
+    timeout_in_millis,
+    style,
+    reasoning,
+    content_type
   } = validatedArgs;
   let instructionsList = [...(instructions ?? [])];
 
@@ -135,6 +156,15 @@ export async function translateHandler(args: unknown, lara: Translator) {
   }
   if (typeof timeout_in_millis !== "undefined") {
     options.timeoutInMillis = timeout_in_millis;
+  }
+  if (typeof style !== "undefined") {
+    options.style = style;
+  }
+  if (typeof reasoning !== "undefined") {
+    options.reasoning = reasoning;
+  }
+  if (typeof content_type !== "undefined") {
+    options.contentType = content_type;
   }
 
   const result = await lara.translate(text, source ?? null, target, options);


### PR DESCRIPTION
## New
- `style` option (faithful/fluid/creative) to control translation readability
- `reasoning` option to enable Lara Think multi-step linguistic analysis
- `content_type` option to specify input format (text/plain, text/html, application/xliff+xml)
- Schema validation and handler tests for all three new options