### PR TITLE
fix: harden temp file handling in import tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,20 @@ All MCP tools are organized in individual files under `src/mcp/tools/`:
 - `list_glossaries.ts` - List all glossaries
 - `get_glossary.ts` - Get glossary by ID (returns null if not found)
   - Validates glossary ID format with regex `/^gls_[a-zA-Z0-9_-]+$/`
+- `create_glossary.ts` - Create a new glossary with a name (max 250 chars)
+- `update_glossary.ts` - Update glossary name by ID
+- `delete_glossary.ts` - Delete a glossary by ID
+- `import_glossary_csv.ts` - Import CSV into a glossary
+  - Supports `csv/table-uni` (default) and `csv/table-multi` content types
+  - Optional gzip compression flag
+  - 5MB size limit on CSV content
+  - Uses temp-file pattern (write to temp, call SDK, cleanup in finally)
+- `check_glossary_import_status.ts` - Check glossary CSV import job status
+  - Takes import job ID (not glossary ID, so no gls_ regex validation)
+- `export_glossary.ts` - Export glossary as CSV
+  - Required `content_type` enum (`csv/table-uni` or `csv/table-multi`)
+  - Optional `source` language (required for `csv/table-uni` per API docs)
+- `get_glossary_counts.ts` - Get term and language counts for a glossary
 
 **Memory Management Tools:**
 - `list_memories.ts` - List all translation memories

--- a/src/__tests__/tools/check_glossary_import_status.test.ts
+++ b/src/__tests__/tools/check_glossary_import_status.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { checkGlossaryImportStatus, checkGlossaryImportStatusSchema } from '../../mcp/tools/check_glossary_import_status.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('checkGlossaryImportStatusSchema', () => {
+  it('should validate correct input', () => {
+    expect(() => checkGlossaryImportStatusSchema.parse({ id: 'import_job_123' })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => checkGlossaryImportStatusSchema.parse({})).toThrow();
+  });
+});
+
+describe('checkGlossaryImportStatus', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.getImportStatus with correct id', async () => {
+    const mockResult = { import_id: 'import_job_123', status: 'completed' };
+    mockTranslator.glossaries.getImportStatus.mockResolvedValue(mockResult);
+
+    const result = await checkGlossaryImportStatus({ id: 'import_job_123' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.getImportStatus).toHaveBeenCalledWith('import_job_123');
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/tools/create_glossary.test.ts
+++ b/src/__tests__/tools/create_glossary.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createGlossary, createGlossarySchema } from '../../mcp/tools/create_glossary.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('createGlossarySchema', () => {
+  it('should validate valid input', () => {
+    expect(() => createGlossarySchema.parse({ name: 'brand_terms' })).not.toThrow();
+  });
+
+  it('should reject missing name', () => {
+    expect(() => createGlossarySchema.parse({})).toThrow();
+  });
+
+  it('should reject name longer than 250 characters', () => {
+    expect(() => createGlossarySchema.parse({ name: 'a'.repeat(251) })).toThrow();
+  });
+});
+
+describe('createGlossary', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.create with correct name', async () => {
+    const mockResult = { id: 'gls_abc123', name: 'brand_terms' };
+    mockTranslator.glossaries.create.mockResolvedValue(mockResult);
+
+    const result = await createGlossary({ name: 'brand_terms' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.create).toHaveBeenCalledWith('brand_terms');
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/tools/delete_glossary.test.ts
+++ b/src/__tests__/tools/delete_glossary.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { deleteGlossary, deleteGlossarySchema } from '../../mcp/tools/delete_glossary.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('deleteGlossarySchema', () => {
+  it('should validate correct input', () => {
+    expect(() => deleteGlossarySchema.parse({ id: 'gls_xyz123' })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => deleteGlossarySchema.parse({})).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    expect(() => deleteGlossarySchema.parse({ id: 'invalid-id' })).toThrow();
+  });
+});
+
+describe('deleteGlossary', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.delete with correct id', async () => {
+    mockTranslator.glossaries.delete.mockResolvedValue(undefined);
+
+    const result = await deleteGlossary({ id: 'gls_xyz123' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.delete).toHaveBeenCalledWith('gls_xyz123');
+  });
+});

--- a/src/__tests__/tools/export_glossary.test.ts
+++ b/src/__tests__/tools/export_glossary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { exportGlossary, exportGlossarySchema } from '../../mcp/tools/export_glossary.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('exportGlossarySchema', () => {
+  it('should validate correct input with source', () => {
+    expect(() => exportGlossarySchema.parse({
+      id: 'gls_xyz123',
+      content_type: 'csv/table-uni',
+      source: 'en',
+    })).not.toThrow();
+  });
+
+  it('should validate correct input without source', () => {
+    expect(() => exportGlossarySchema.parse({
+      id: 'gls_xyz123',
+      content_type: 'csv/table-multi',
+    })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => exportGlossarySchema.parse({
+      content_type: 'csv/table-uni',
+    })).toThrow();
+  });
+
+  it('should reject missing content_type', () => {
+    expect(() => exportGlossarySchema.parse({
+      id: 'gls_xyz123',
+    })).toThrow();
+  });
+
+  it('should reject invalid content_type', () => {
+    expect(() => exportGlossarySchema.parse({
+      id: 'gls_xyz123',
+      content_type: 'invalid',
+    })).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    expect(() => exportGlossarySchema.parse({
+      id: 'invalid-id',
+      content_type: 'csv/table-uni',
+    })).toThrow();
+  });
+});
+
+describe('exportGlossary', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.export with correct params', async () => {
+    const mockCsv = 'source,target\nhello,ciao';
+    mockTranslator.glossaries.export.mockResolvedValue(mockCsv);
+
+    const result = await exportGlossary({
+      id: 'gls_xyz123',
+      content_type: 'csv/table-uni',
+      source: 'en',
+    }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.export).toHaveBeenCalledWith('gls_xyz123', 'csv/table-uni', 'en');
+    expect(result).toBe(mockCsv);
+  });
+
+  it('should call lara.glossaries.export without source when not provided', async () => {
+    mockTranslator.glossaries.export.mockResolvedValue('col1,col2');
+
+    await exportGlossary({
+      id: 'gls_xyz123',
+      content_type: 'csv/table-multi',
+    }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.export).toHaveBeenCalledWith('gls_xyz123', 'csv/table-multi', undefined);
+  });
+});

--- a/src/__tests__/tools/get_glossary_counts.test.ts
+++ b/src/__tests__/tools/get_glossary_counts.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getGlossaryCounts, getGlossaryCountsSchema } from '../../mcp/tools/get_glossary_counts.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('getGlossaryCountsSchema', () => {
+  it('should validate correct input', () => {
+    expect(() => getGlossaryCountsSchema.parse({ id: 'gls_xyz123' })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => getGlossaryCountsSchema.parse({})).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    expect(() => getGlossaryCountsSchema.parse({ id: 'invalid-id' })).toThrow();
+  });
+});
+
+describe('getGlossaryCounts', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.counts with correct id', async () => {
+    const mockResult = { terms: 150, languages: 3 };
+    mockTranslator.glossaries.counts.mockResolvedValue(mockResult);
+
+    const result = await getGlossaryCounts({ id: 'gls_xyz123' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.counts).toHaveBeenCalledWith('gls_xyz123');
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/tools/import_glossary_csv.test.ts
+++ b/src/__tests__/tools/import_glossary_csv.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { importGlossaryCsv, importGlossaryCsvSchema } from '../../mcp/tools/import_glossary_csv.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('importGlossaryCsvSchema', () => {
+  it('should validate valid input with all fields', () => {
+    expect(() => importGlossaryCsvSchema.parse({
+      id: 'gls_xyz123',
+      csv_content: 'source,target\nhello,ciao',
+      content_type: 'csv/table-multi',
+      gzip: false,
+    })).not.toThrow();
+  });
+
+  it('should validate with defaults', () => {
+    const result = importGlossaryCsvSchema.parse({
+      id: 'gls_xyz123',
+      csv_content: 'source,target\nhello,ciao',
+    });
+    expect(result.content_type).toBe('csv/table-uni');
+  });
+
+  it('should reject missing id', () => {
+    expect(() => importGlossaryCsvSchema.parse({
+      csv_content: 'source,target\nhello,ciao',
+    })).toThrow();
+  });
+
+  it('should reject missing csv_content', () => {
+    expect(() => importGlossaryCsvSchema.parse({
+      id: 'gls_xyz123',
+    })).toThrow();
+  });
+
+  it('should reject invalid content_type', () => {
+    expect(() => importGlossaryCsvSchema.parse({
+      id: 'gls_xyz123',
+      csv_content: 'source,target\nhello,ciao',
+      content_type: 'invalid',
+    })).toThrow();
+  });
+});
+
+describe('importGlossaryCsv', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.glossaries.importCsv.mockResolvedValue({
+      import_id: 'mock_import_id',
+      status: 'queued',
+    });
+  });
+
+  it('should call lara.glossaries.importCsv with correct parameters', async () => {
+    const args = {
+      id: 'gls_xyz123',
+      csv_content: 'source,target\nhello,ciao',
+      content_type: 'csv/table-multi',
+    };
+
+    await importGlossaryCsv(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.importCsv).toHaveBeenCalledWith(
+      'gls_xyz123',
+      expect.stringContaining('import.csv'),
+      'csv/table-multi',
+      undefined,
+    );
+  });
+
+  it('should throw error for CSV content exceeding 5MB', async () => {
+    const largeContent = 'a'.repeat(6 * 1024 * 1024);
+
+    await expect(importGlossaryCsv({
+      id: 'gls_xyz123',
+      csv_content: largeContent,
+    }, mockTranslator as any as Translator)).rejects.toThrow('CSV file too large');
+  });
+});

--- a/src/__tests__/tools/import_glossary_csv.test.ts
+++ b/src/__tests__/tools/import_glossary_csv.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { importGlossaryCsv, importGlossaryCsvSchema } from '../../mcp/tools/import_glossary_csv.js';
 import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
 import { Translator } from '@translated/lara';

--- a/src/__tests__/tools/import_tmx.test.ts
+++ b/src/__tests__/tools/import_tmx.test.ts
@@ -64,4 +64,13 @@ describe('importTmx input validation', () => {
 
     await importTmx(args, mockTranslator as any as Translator);
   });
-}); 
+
+  it('should throw InvalidInputError for TMX content exceeding 5MB', async () => {
+    const largeContent = 'a'.repeat(6 * 1024 * 1024);
+
+    await expect(importTmx({
+      id: 'mem_xyz123',
+      tmx_content: largeContent,
+    }, mockTranslator as any as Translator)).rejects.toThrow('TMX file too large');
+  });
+});

--- a/src/__tests__/tools/update_glossary.test.ts
+++ b/src/__tests__/tools/update_glossary.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { updateGlossary, updateGlossarySchema } from '../../mcp/tools/update_glossary.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('updateGlossarySchema', () => {
+  it('should validate correct input', () => {
+    expect(() => updateGlossarySchema.parse({ id: 'gls_xyz123', name: 'new_name' })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => updateGlossarySchema.parse({ name: 'new_name' })).toThrow();
+  });
+
+  it('should reject missing name', () => {
+    expect(() => updateGlossarySchema.parse({ id: 'gls_xyz123' })).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    expect(() => updateGlossarySchema.parse({ id: 'invalid-id', name: 'new_name' })).toThrow();
+  });
+
+  it('should reject name longer than 250 characters', () => {
+    expect(() => updateGlossarySchema.parse({ id: 'gls_xyz123', name: 'a'.repeat(251) })).toThrow();
+  });
+});
+
+describe('updateGlossary', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.update with correct id and name', async () => {
+    const mockResult = { id: 'gls_xyz123', name: 'new_name' };
+    mockTranslator.glossaries.update.mockResolvedValue(mockResult);
+
+    const result = await updateGlossary({ id: 'gls_xyz123', name: 'new_name' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.update).toHaveBeenCalledWith('gls_xyz123', 'new_name');
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -35,6 +35,13 @@ export function createMockTranslator() {
     glossaries: {
       list: vi.fn(),
       get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      importCsv: vi.fn(),
+      getImportStatus: vi.fn(),
+      export: vi.fn(),
+      counts: vi.fn(),
     },
     client: {}
   };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -24,6 +24,13 @@ import { listLanguages, listLanguagesSchema } from "./tools/list_languages.js";
 import { listMemories, listMemoriesSchema } from "./tools/list_memories.js";
 import { listGlossaries, listGlossariesSchema } from "./tools/list_glossaries.js";
 import { getGlossary, getGlossarySchema } from "./tools/get_glossary.js";
+import { createGlossary, createGlossarySchema } from "./tools/create_glossary.js";
+import { updateGlossary, updateGlossarySchema } from "./tools/update_glossary.js";
+import { deleteGlossary, deleteGlossarySchema } from "./tools/delete_glossary.js";
+import { importGlossaryCsv, importGlossaryCsvSchema } from "./tools/import_glossary_csv.js";
+import { checkGlossaryImportStatus, checkGlossaryImportStatusSchema } from "./tools/check_glossary_import_status.js";
+import { exportGlossary, exportGlossarySchema } from "./tools/export_glossary.js";
+import { getGlossaryCounts, getGlossaryCountsSchema } from "./tools/get_glossary_counts.js";
 import { translateHandler, translateSchema } from "./tools/translate.js";
 import {
   updateMemory,
@@ -45,6 +52,13 @@ const handlers: Record<string, Handler> = {
   import_tmx: importTmx,
   check_import_status: checkImportStatus,
   get_glossary: getGlossary,
+  create_glossary: createGlossary,
+  update_glossary: updateGlossary,
+  delete_glossary: deleteGlossary,
+  import_glossary_csv: importGlossaryCsv,
+  check_glossary_import_status: checkGlossaryImportStatus,
+  export_glossary: exportGlossary,
+  get_glossary_counts: getGlossaryCounts,
 };
 
 const listers: Record<string, Lister> = {
@@ -176,6 +190,48 @@ async function ListTools() {
         description:
           "Retrieves a specific glossary by ID from your Lara Translate account. Returns null if the glossary is not found.",
         inputSchema: z.toJSONSchema(getGlossarySchema),
+      },
+      {
+        name: "create_glossary",
+        description:
+          "Create a glossary with a custom name in your Lara Translate account. Glossaries enforce specific terminology during translation.",
+        inputSchema: z.toJSONSchema(createGlossarySchema),
+      },
+      {
+        name: "update_glossary",
+        description:
+          "Updates the name of a glossary in your Lara Translate account.",
+        inputSchema: z.toJSONSchema(updateGlossarySchema),
+      },
+      {
+        name: "delete_glossary",
+        description:
+          "Deletes a glossary from your Lara Translate account.",
+        inputSchema: z.toJSONSchema(deleteGlossarySchema),
+      },
+      {
+        name: "import_glossary_csv",
+        description:
+          "Imports a CSV file into a glossary in your Lara Translate account. Supports unidirectional and multidirectional formats.",
+        inputSchema: z.toJSONSchema(importGlossaryCsvSchema),
+      },
+      {
+        name: "check_glossary_import_status",
+        description:
+          "Checks the status of a glossary CSV import job in your Lara Translate account.",
+        inputSchema: z.toJSONSchema(checkGlossaryImportStatusSchema),
+      },
+      {
+        name: "export_glossary",
+        description:
+          "Exports a glossary as CSV from your Lara Translate account. Supports unidirectional and multidirectional formats.",
+        inputSchema: z.toJSONSchema(exportGlossarySchema),
+      },
+      {
+        name: "get_glossary_counts",
+        description:
+          "Retrieves the term and language counts for a glossary in your Lara Translate account.",
+        inputSchema: z.toJSONSchema(getGlossaryCountsSchema),
       },
     ],
   };

--- a/src/mcp/tools/check_glossary_import_status.ts
+++ b/src/mcp/tools/check_glossary_import_status.ts
@@ -1,0 +1,13 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const checkGlossaryImportStatusSchema = z.object({
+  id: z.string().describe("The ID of the glossary import job"),
+});
+
+export async function checkGlossaryImportStatus(args: any, lara: Translator) {
+  const validatedArgs = checkGlossaryImportStatusSchema.parse(args);
+  const { id } = validatedArgs;
+
+  return await lara.glossaries.getImportStatus(id);
+}

--- a/src/mcp/tools/create_glossary.ts
+++ b/src/mcp/tools/create_glossary.ts
@@ -1,0 +1,19 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const createGlossarySchema = z.object({
+  name: z
+    .string()
+    .describe(
+      "The name of the new glossary, it should be short and descriptive, like 'brand_terms' or 'legal_terminology'"
+    )
+    .refine((name) => name.length <= 250, {
+      message: "Name of the glossary can't be more than 250 characters",
+    }),
+});
+
+export async function createGlossary(args: any, lara: Translator) {
+  const validatedArgs = createGlossarySchema.parse(args);
+  const { name } = validatedArgs;
+  return await lara.glossaries.create(name);
+}

--- a/src/mcp/tools/delete_glossary.ts
+++ b/src/mcp/tools/delete_glossary.ts
@@ -1,0 +1,16 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const deleteGlossarySchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID to delete (format: gls_*, e.g., 'gls_xyz123')"),
+});
+
+export async function deleteGlossary(args: any, lara: Translator) {
+  const validatedArgs = deleteGlossarySchema.parse(args);
+  const { id } = validatedArgs;
+  return await lara.glossaries.delete(id);
+}

--- a/src/mcp/tools/export_glossary.ts
+++ b/src/mcp/tools/export_glossary.ts
@@ -1,0 +1,24 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const exportGlossarySchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID (format: gls_*, e.g., 'gls_xyz123')"),
+  content_type: z
+    .enum(["csv/table-uni", "csv/table-multi"])
+    .describe("The export format. 'csv/table-uni' for unidirectional (requires source parameter), 'csv/table-multi' for multidirectional"),
+  source: z
+    .string()
+    .optional()
+    .describe("The source language code. Required when content_type is 'csv/table-uni'"),
+});
+
+export async function exportGlossary(args: any, lara: Translator) {
+  const validatedArgs = exportGlossarySchema.parse(args);
+  const { id, content_type, source } = validatedArgs;
+
+  return await lara.glossaries.export(id, content_type, source);
+}

--- a/src/mcp/tools/get_glossary_counts.ts
+++ b/src/mcp/tools/get_glossary_counts.ts
@@ -1,0 +1,17 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const getGlossaryCountsSchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID (format: gls_*, e.g., 'gls_xyz123')"),
+});
+
+export async function getGlossaryCounts(args: any, lara: Translator) {
+  const validatedArgs = getGlossaryCountsSchema.parse(args);
+  const { id } = validatedArgs;
+
+  return await lara.glossaries.counts(id);
+}

--- a/src/mcp/tools/import_glossary_csv.ts
+++ b/src/mcp/tools/import_glossary_csv.ts
@@ -1,0 +1,50 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { InvalidInputError } from "#exception";
+
+export const importGlossaryCsvSchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID (format: gls_*, e.g., 'gls_xyz123')"),
+  csv_content: z
+    .string()
+    .describe("The content of the CSV file to upload"),
+  content_type: z
+    .enum(["csv/table-uni", "csv/table-multi"])
+    .default("csv/table-uni")
+    .describe("The format of the CSV file. 'csv/table-uni' for unidirectional, 'csv/table-multi' for multidirectional"),
+  gzip: z
+    .boolean()
+    .optional()
+    .describe("Whether the CSV content is gzip compressed"),
+});
+
+export async function importGlossaryCsv(args: any, lara: Translator) {
+  const validatedArgs = importGlossaryCsvSchema.parse(args);
+  const { id, csv_content, content_type, gzip } = validatedArgs;
+
+  // File size limit: 5MB
+  const MAX_CSV_SIZE = 5 * 1024 * 1024;
+  if (Buffer.byteLength(csv_content, 'utf8') > MAX_CSV_SIZE) {
+    throw new InvalidInputError("CSV file too large. Maximum allowed size is 5MB.");
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lara-csv-'));
+  const tempFilePath = path.join(tempDir, 'import.csv');
+
+  try {
+    fs.writeFileSync(tempFilePath, csv_content, { mode: 0o600 });
+
+    return await lara.glossaries.importCsv(id, tempFilePath, content_type, gzip);
+  } finally {
+    try {
+      fs.unlinkSync(tempFilePath);
+      fs.rmdirSync(tempDir);
+    } catch (_) { /* best-effort cleanup */ }
+  }
+}

--- a/src/mcp/tools/import_glossary_csv.ts
+++ b/src/mcp/tools/import_glossary_csv.ts
@@ -43,8 +43,7 @@ export async function importGlossaryCsv(args: any, lara: Translator) {
     return await lara.glossaries.importCsv(id, tempFilePath, content_type, gzip);
   } finally {
     try {
-      fs.unlinkSync(tempFilePath);
-      fs.rmdirSync(tempDir);
+      fs.rmSync(tempDir, { recursive: true, force: true });
     } catch (_) { /* best-effort cleanup */ }
   }
 }

--- a/src/mcp/tools/import_tmx.ts
+++ b/src/mcp/tools/import_tmx.ts
@@ -37,8 +37,7 @@ export async function importTmx(args: any, lara: Translator) {
     return await lara.memories.importTmx(id, tempFilePath);
   } finally {
     try {
-      fs.unlinkSync(tempFilePath);
-      fs.rmdirSync(tempDir);
+      fs.rmSync(tempDir, { recursive: true, force: true });
     } catch (_) { /* best-effort cleanup */ }
   }
 }

--- a/src/mcp/tools/import_tmx.ts
+++ b/src/mcp/tools/import_tmx.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { InvalidInputError } from "#exception";
 
 export const importTmxSchema = z.object({
   id: z
@@ -22,27 +23,22 @@ export async function importTmx(args: any, lara: Translator) {
   const { id, tmx_content } = validatedArgs;
 
   // File size limit: 5MB
-  const MAX_TMX_SIZE = 5 * 1024 * 1024; // 5MB
+  const MAX_TMX_SIZE = 5 * 1024 * 1024;
   if (Buffer.byteLength(tmx_content, 'utf8') > MAX_TMX_SIZE) {
-    throw new Error("TMX file too large. Maximum allowed size is 5MB.");
+    throw new InvalidInputError("TMX file too large. Maximum allowed size is 5MB.");
   }
 
-  const tempDir = path.join(os.tmpdir(), 'lara-tmx-imports');
-  if (!fs.existsSync(tempDir)) {
-    fs.mkdirSync(tempDir, { recursive: true });
-  }
-
-  const tempFilePath = path.join(tempDir, `tmx-${Date.now()}-${Math.random().toString(36).slice(2)}.tmx`);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lara-tmx-'));
+  const tempFilePath = path.join(tempDir, 'import.tmx');
 
   try {
-    fs.writeFileSync(tempFilePath, tmx_content);
+    fs.writeFileSync(tempFilePath, tmx_content, { mode: 0o600 });
 
     return await lara.memories.importTmx(id, tempFilePath);
-  } catch (err) {
-    throw err;
   } finally {
-    if (fs.existsSync(tempFilePath)) {
+    try {
       fs.unlinkSync(tempFilePath);
-    }
+      fs.rmdirSync(tempDir);
+    } catch (_) { /* best-effort cleanup */ }
   }
 }

--- a/src/mcp/tools/update_glossary.ts
+++ b/src/mcp/tools/update_glossary.ts
@@ -1,0 +1,22 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const updateGlossarySchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID (format: gls_*, e.g., 'gls_xyz123')"),
+  name: z
+    .string()
+    .describe("The new name for the glossary")
+    .refine((name) => name.length <= 250, {
+      message: "Name can't be more than 250 characters",
+    }),
+});
+
+export async function updateGlossary(args: any, lara: Translator) {
+  const validatedArgs = updateGlossarySchema.parse(args);
+  const { id, name } = validatedArgs;
+  return await lara.glossaries.update(id, name);
+}


### PR DESCRIPTION
## Changed
- Use mkdtempSync for isolated per-request temp dirs instead of shared predictable paths
- Set file permissions to 0600 (owner-only) on temp files
- Use InvalidInputError for size limit errors instead of generic Error
- Clean up both temp file and directory in finally block
- Remove TOCTOU race condition (existsSync + mkdirSync)