### PR TITLE
fix: surface meaningful error messages to clients

### DIFF
--- a/src/__tests__/tools/add_translation.test.ts
+++ b/src/__tests__/tools/add_translation.test.ts
@@ -121,10 +121,9 @@ describe('addTranslation', () => {
       // Missing sentence_after
     };
 
-    await expect(addTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(addTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
+    const promise = addTranslation(args, mockTranslator as any as Translator);
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow(
       'Please provide both sentence_before and sentence_after'
     );
   });

--- a/src/__tests__/tools/add_translation.test.ts
+++ b/src/__tests__/tools/add_translation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { addTranslation, addTranslationSchema } from '../../mcp/tools/add_translation.js';
 import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
 import { Translator } from '@translated/lara';
+import { InvalidInputError } from '../../exception.js';
 
 // Setup mocks
 setupTranslatorMock();
@@ -120,6 +121,9 @@ describe('addTranslation', () => {
       // Missing sentence_after
     };
 
+    await expect(addTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
     await expect(addTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
       'Please provide both sentence_before and sentence_after'
     );

--- a/src/__tests__/tools/call_tool.test.ts
+++ b/src/__tests__/tools/call_tool.test.ts
@@ -71,7 +71,7 @@ describe('CallTool error handling', () => {
 
   it('should preserve InvalidInputError as-is', async () => {
     mockTranslator.memories.addTranslation.mockImplementation(() => {
-      throw new InvalidInputError('Please provide both sentence_before and sentence_after');
+      throw new InvalidInputError('Custom validation error from handler');
     });
 
     const request = makeRequest('add_translation', {
@@ -82,13 +82,14 @@ describe('CallTool error handling', () => {
       translation: 'Ciao',
       tuid: 'tu_1',
       sentence_before: 'Hi',
+      sentence_after: 'Goodbye',
     });
 
     await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
       InvalidInputError
     );
     await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      'Please provide both sentence_before and sentence_after'
+      'Custom validation error from handler'
     );
   });
 

--- a/src/__tests__/tools/call_tool.test.ts
+++ b/src/__tests__/tools/call_tool.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CallTool } from '../../mcp/tools.js';
+import { createMockTranslator, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+import { InvalidInputError } from '../../exception.js';
+import type { CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const actualLara = await vi.importActual<typeof import('@translated/lara')>('@translated/lara');
+const { LaraApiError, TimeoutError: LaraTimeoutError } = actualLara;
+
+vi.mock('@translated/lara', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@translated/lara')>();
+  return {
+    ...actual,
+    Translator: vi.fn(() => createMockTranslator()),
+  };
+});
+
+function makeRequest(name: string, args: Record<string, unknown> = {}): CallToolRequest {
+  return {
+    method: 'tools/call',
+    params: { name, arguments: args },
+  } as CallToolRequest;
+}
+
+describe('CallTool error handling', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = new (Translator as any)();
+  });
+
+  it('should surface LaraApiError message', async () => {
+    const apiError = new LaraApiError(404, 'not_found', 'Memory not found');
+    mockTranslator.memories.delete.mockRejectedValue(apiError);
+
+    const request = makeRequest('delete_memory', { id: 'mem_abc123' });
+
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      'Memory not found'
+    );
+  });
+
+  it('should surface timeout error message', async () => {
+    const timeoutError = new LaraTimeoutError('Request timed out');
+    mockTranslator.memories.delete.mockRejectedValue(timeoutError);
+
+    const request = makeRequest('delete_memory', { id: 'mem_abc123' });
+
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      'The translation request timed out. Try again or increase the timeout.'
+    );
+  });
+
+  it('should include field names and reasons in Zod validation errors', async () => {
+    const request = makeRequest('delete_memory', { id: 123 });
+
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      /Invalid input:.*id/
+    );
+  });
+
+  it('should preserve InvalidInputError as-is', async () => {
+    mockTranslator.memories.addTranslation.mockImplementation(() => {
+      throw new InvalidInputError('Please provide both sentence_before and sentence_after');
+    });
+
+    const request = makeRequest('add_translation', {
+      id: ['mem_abc123'],
+      source: 'en-US',
+      target: 'it-IT',
+      sentence: 'Hello',
+      translation: 'Ciao',
+      tuid: 'tu_1',
+      sentence_before: 'Hi',
+    });
+
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      'Please provide both sentence_before and sentence_after'
+    );
+  });
+
+  it('should return generic message for unknown errors', async () => {
+    mockTranslator.memories.delete.mockRejectedValue(new TypeError('Something unexpected'));
+
+    const request = makeRequest('delete_memory', { id: 'mem_abc123' });
+
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      'An error occurred while processing your request'
+    );
+  });
+
+  it('should throw InvalidInputError for unknown tool names', async () => {
+    const request = makeRequest('nonexistent_tool', {});
+
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
+    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+      'Tool nonexistent_tool not found'
+    );
+  });
+});

--- a/src/__tests__/tools/call_tool.test.ts
+++ b/src/__tests__/tools/call_tool.test.ts
@@ -62,6 +62,15 @@ describe('CallTool error handling', () => {
     await expect(promise).rejects.toThrow(/Invalid input:.*id/);
   });
 
+  it('should use "arguments" label for root-level Zod errors', async () => {
+    // Passing a non-object triggers a root-level Zod error with empty path
+    const request = makeRequest('delete_memory', 'not-an-object' as any);
+    const promise = CallTool(request, mockTranslator as any as Translator);
+
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow(/Invalid input: arguments:/);
+  });
+
   it('should preserve InvalidInputError as-is', async () => {
     mockTranslator.memories.addTranslation.mockImplementation(() => {
       throw new InvalidInputError('Custom validation error from handler');

--- a/src/__tests__/tools/call_tool.test.ts
+++ b/src/__tests__/tools/call_tool.test.ts
@@ -35,13 +35,10 @@ describe('CallTool error handling', () => {
     mockTranslator.memories.delete.mockRejectedValue(apiError);
 
     const request = makeRequest('delete_memory', { id: 'mem_abc123' });
+    const promise = CallTool(request, mockTranslator as any as Translator);
 
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      'Memory not found'
-    );
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow('Memory not found');
   });
 
   it('should surface timeout error message', async () => {
@@ -49,24 +46,20 @@ describe('CallTool error handling', () => {
     mockTranslator.memories.delete.mockRejectedValue(timeoutError);
 
     const request = makeRequest('delete_memory', { id: 'mem_abc123' });
+    const promise = CallTool(request, mockTranslator as any as Translator);
 
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow(
       'The translation request timed out. Try again or increase the timeout.'
     );
   });
 
   it('should include field names and reasons in Zod validation errors', async () => {
     const request = makeRequest('delete_memory', { id: 123 });
+    const promise = CallTool(request, mockTranslator as any as Translator);
 
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      /Invalid input:.*id/
-    );
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow(/Invalid input:.*id/);
   });
 
   it('should preserve InvalidInputError as-is', async () => {
@@ -84,36 +77,27 @@ describe('CallTool error handling', () => {
       sentence_before: 'Hi',
       sentence_after: 'Goodbye',
     });
+    const promise = CallTool(request, mockTranslator as any as Translator);
 
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      'Custom validation error from handler'
-    );
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow('Custom validation error from handler');
   });
 
   it('should return generic message for unknown errors', async () => {
     mockTranslator.memories.delete.mockRejectedValue(new TypeError('Something unexpected'));
 
     const request = makeRequest('delete_memory', { id: 'mem_abc123' });
+    const promise = CallTool(request, mockTranslator as any as Translator);
 
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      'An error occurred while processing your request'
-    );
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow('An error occurred while processing your request');
   });
 
   it('should throw InvalidInputError for unknown tool names', async () => {
     const request = makeRequest('nonexistent_tool', {});
+    const promise = CallTool(request, mockTranslator as any as Translator);
 
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(CallTool(request, mockTranslator as any as Translator)).rejects.toThrow(
-      'Tool nonexistent_tool not found'
-    );
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow('Tool nonexistent_tool not found');
   });
 });

--- a/src/__tests__/tools/delete_translation.test.ts
+++ b/src/__tests__/tools/delete_translation.test.ts
@@ -121,10 +121,9 @@ describe('deleteTranslation', () => {
       // Missing sentence_after
     };
 
-    await expect(deleteTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
-      InvalidInputError
-    );
-    await expect(deleteTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
+    const promise = deleteTranslation(args, mockTranslator as any as Translator);
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow(
       'Please provide both sentence_before and sentence_after'
     );
   });

--- a/src/__tests__/tools/delete_translation.test.ts
+++ b/src/__tests__/tools/delete_translation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { deleteTranslation, deleteTranslationSchema } from '../../mcp/tools/delete_translation.js';
 import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
 import { Translator } from '@translated/lara';
+import { InvalidInputError } from '../../exception.js';
 
 // Setup mocks
 setupTranslatorMock();
@@ -120,6 +121,9 @@ describe('deleteTranslation', () => {
       // Missing sentence_after
     };
 
+    await expect(deleteTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
+      InvalidInputError
+    );
     await expect(deleteTranslation(args, mockTranslator as any as Translator)).rejects.toThrow(
       'Please provide both sentence_before and sentence_after'
     );

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -2,7 +2,7 @@ import {
   CallToolRequest,
   CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
-import { Translator } from "@translated/lara";
+import { LaraApiError, TimeoutError as LaraTimeoutError, Translator } from "@translated/lara";
 import * as z from "zod/v4";
 
 import {
@@ -94,18 +94,26 @@ async function CallTool(
     throw new InvalidInputError(`Tool ${name} not found`);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      // Don't expose technical validation details
       const fieldErrors = error.issues
-        .map(i => i.path.join('.'))
-        .join(', ');
-      throw new InvalidInputError(
-        `Invalid input in fields: ${fieldErrors}`
-      );
+        .map(i => {
+          const field = i.path.join('.');
+          return `${field}: ${i.message}`;
+        })
+        .join('; ');
+      throw new InvalidInputError(`Invalid input: ${fieldErrors}`);
     }
 
     // Preserve existing InvalidInputError instances (and their messages)
     if (error instanceof InvalidInputError) {
       throw error;
+    }
+
+    if (error instanceof LaraApiError) {
+      throw new InvalidInputError(error.message);
+    }
+
+    if (error instanceof LaraTimeoutError) {
+      throw new InvalidInputError("The translation request timed out. Try again or increase the timeout.");
     }
 
     // Log full error internally for debugging

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -96,7 +96,7 @@ async function CallTool(
     if (error instanceof z.ZodError) {
       const fieldErrors = error.issues
         .map(i => {
-          const field = i.path.join('.');
+          const field = i.path.length > 0 ? i.path.join('.') : 'arguments';
           return `${field}: ${i.message}`;
         })
         .join('; ');

--- a/src/mcp/tools/add_translation.ts
+++ b/src/mcp/tools/add_translation.ts
@@ -1,5 +1,6 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { InvalidInputError } from "#exception";
 
 export const addTranslationSchema = z.object({
   id: z
@@ -61,7 +62,7 @@ export async function addTranslation(args: unknown, lara: Translator) {
     (sentence_before && !sentence_after) ||
     (!sentence_before && sentence_after)
   ) {
-    throw new Error("Please provide both sentence_before and sentence_after");
+    throw new InvalidInputError("Please provide both sentence_before and sentence_after");
   }
 
   return await lara.memories.addTranslation(

--- a/src/mcp/tools/delete_translation.ts
+++ b/src/mcp/tools/delete_translation.ts
@@ -1,5 +1,6 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { InvalidInputError } from "#exception";
 
 export const deleteTranslationSchema = z.object({
   id: z
@@ -53,7 +54,7 @@ export async function deleteTranslation(args: any, lara: Translator) {
     (sentence_before && !sentence_after) ||
     (!sentence_before && sentence_after)
   ) {
-    throw new Error("Please provide both sentence_before and sentence_after");
+    throw new InvalidInputError("Please provide both sentence_before and sentence_after");
   }
 
   return await lara.memories.deleteTranslation(


### PR DESCRIPTION
## Changed
- Zod validation errors now include field names with reasons instead of just field names
- `add_translation` and `delete_translation` throw `InvalidInputError` instead of bare `Error`

## New
- `LaraApiError` messages from the SDK are surfaced directly to clients
- `TimeoutError` returns a descriptive timeout message instead of generic error
- CallTool error handling test suite covering all error branches