### PR TITLE
feat: add glossary entry management tools

### DIFF
--- a/src/__tests__/tools/add_glossary_entry.test.ts
+++ b/src/__tests__/tools/add_glossary_entry.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { addGlossaryEntry, addGlossaryEntrySchema } from '../../mcp/tools/add_glossary_entry.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('addGlossaryEntrySchema', () => {
+  it('should validate correct input with required fields', () => {
+    const input = {
+      id: 'gls_xyz123',
+      terms: [{ language: 'en-US', value: 'Hello' }],
+    };
+    expect(() => addGlossaryEntrySchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate correct input with optional guid', () => {
+    const input = {
+      id: 'gls_xyz123',
+      terms: [{ language: 'en-US', value: 'Hello' }, { language: 'it-IT', value: 'Ciao' }],
+      guid: 'entry-123',
+    };
+    expect(() => addGlossaryEntrySchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    const input = {
+      terms: [{ language: 'en-US', value: 'Hello' }],
+    };
+    expect(() => addGlossaryEntrySchema.parse(input)).toThrow();
+  });
+
+  it('should reject empty terms array', () => {
+    const input = {
+      id: 'gls_xyz123',
+      terms: [],
+    };
+    expect(() => addGlossaryEntrySchema.parse(input)).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      id: 'invalid-id',
+      terms: [{ language: 'en-US', value: 'Hello' }],
+    };
+    expect(() => addGlossaryEntrySchema.parse(input)).toThrow();
+  });
+});
+
+describe('addGlossaryEntry', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.addOrReplaceEntry without guid', async () => {
+    const mockResult = { id: 'imp_abc', status: 'pending' };
+    mockTranslator.glossaries.addOrReplaceEntry.mockResolvedValue(mockResult);
+
+    const args = {
+      id: 'gls_xyz123',
+      terms: [{ language: 'en-US', value: 'Hello' }, { language: 'it-IT', value: 'Ciao' }],
+    };
+
+    const result = await addGlossaryEntry(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.addOrReplaceEntry).toHaveBeenCalledWith(
+      'gls_xyz123',
+      args.terms
+    );
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should call lara.glossaries.addOrReplaceEntry with guid when provided', async () => {
+    const mockResult = { id: 'imp_abc', status: 'pending' };
+    mockTranslator.glossaries.addOrReplaceEntry.mockResolvedValue(mockResult);
+
+    const args = {
+      id: 'gls_xyz123',
+      terms: [{ language: 'en-US', value: 'Hello' }],
+      guid: 'entry-123',
+    };
+
+    const result = await addGlossaryEntry(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.addOrReplaceEntry).toHaveBeenCalledWith(
+      'gls_xyz123',
+      args.terms,
+      'entry-123'
+    );
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/tools/delete_glossary_entry.test.ts
+++ b/src/__tests__/tools/delete_glossary_entry.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { deleteGlossaryEntry, deleteGlossaryEntrySchema } from '../../mcp/tools/delete_glossary_entry.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+import { InvalidInputError } from '../../exception.js';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('deleteGlossaryEntrySchema', () => {
+  it('should validate input with term', () => {
+    const input = {
+      id: 'gls_xyz123',
+      term: { language: 'en-US', value: 'Hello' },
+    };
+    expect(() => deleteGlossaryEntrySchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate input with guid', () => {
+    const input = {
+      id: 'gls_xyz123',
+      guid: 'entry-123',
+    };
+    expect(() => deleteGlossaryEntrySchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate input with both term and guid', () => {
+    const input = {
+      id: 'gls_xyz123',
+      term: { language: 'en-US', value: 'Hello' },
+      guid: 'entry-123',
+    };
+    expect(() => deleteGlossaryEntrySchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    const input = {
+      term: { language: 'en-US', value: 'Hello' },
+    };
+    expect(() => deleteGlossaryEntrySchema.parse(input)).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      id: 'invalid-id',
+      term: { language: 'en-US', value: 'Hello' },
+    };
+    expect(() => deleteGlossaryEntrySchema.parse(input)).toThrow();
+  });
+});
+
+describe('deleteGlossaryEntry', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.glossaries.deleteEntry with term', async () => {
+    const mockResult = { id: 'imp_abc', status: 'pending' };
+    mockTranslator.glossaries.deleteEntry.mockResolvedValue(mockResult);
+
+    const args = {
+      id: 'gls_xyz123',
+      term: { language: 'en-US', value: 'Hello' },
+    };
+
+    const result = await deleteGlossaryEntry(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.deleteEntry).toHaveBeenCalledWith(
+      'gls_xyz123',
+      { language: 'en-US', value: 'Hello' },
+      undefined
+    );
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should call lara.glossaries.deleteEntry with guid', async () => {
+    const mockResult = { id: 'imp_abc', status: 'pending' };
+    mockTranslator.glossaries.deleteEntry.mockResolvedValue(mockResult);
+
+    const args = {
+      id: 'gls_xyz123',
+      guid: 'entry-123',
+    };
+
+    const result = await deleteGlossaryEntry(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.glossaries.deleteEntry).toHaveBeenCalledWith(
+      'gls_xyz123',
+      undefined,
+      'entry-123'
+    );
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should throw InvalidInputError when neither term nor guid is provided', async () => {
+    const args = {
+      id: 'gls_xyz123',
+    };
+
+    const promise = deleteGlossaryEntry(args, mockTranslator as any as Translator);
+    await expect(promise).rejects.toThrow(InvalidInputError);
+    await expect(promise).rejects.toThrow("At least one of 'term' or 'guid' must be provided");
+  });
+});

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -42,6 +42,8 @@ export function createMockTranslator() {
       getImportStatus: vi.fn(),
       export: vi.fn(),
       counts: vi.fn(),
+      addOrReplaceEntry: vi.fn(),
+      deleteEntry: vi.fn(),
     },
     client: {}
   };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -31,6 +31,8 @@ import { importGlossaryCsv, importGlossaryCsvSchema } from "./tools/import_gloss
 import { checkGlossaryImportStatus, checkGlossaryImportStatusSchema } from "./tools/check_glossary_import_status.js";
 import { exportGlossary, exportGlossarySchema } from "./tools/export_glossary.js";
 import { getGlossaryCounts, getGlossaryCountsSchema } from "./tools/get_glossary_counts.js";
+import { addGlossaryEntry, addGlossaryEntrySchema } from "./tools/add_glossary_entry.js";
+import { deleteGlossaryEntry, deleteGlossaryEntrySchema } from "./tools/delete_glossary_entry.js";
 import { translateHandler, translateSchema } from "./tools/translate.js";
 import {
   updateMemory,
@@ -59,6 +61,8 @@ const handlers: Record<string, Handler> = {
   check_glossary_import_status: checkGlossaryImportStatus,
   export_glossary: exportGlossary,
   get_glossary_counts: getGlossaryCounts,
+  add_glossary_entry: addGlossaryEntry,
+  delete_glossary_entry: deleteGlossaryEntry,
 };
 
 const listers: Record<string, Lister> = {
@@ -240,6 +244,18 @@ async function ListTools() {
         description:
           "Retrieves the term and language counts for a glossary in your Lara Translate account.",
         inputSchema: z.toJSONSchema(getGlossaryCountsSchema),
+      },
+      {
+        name: "add_glossary_entry",
+        description:
+          "Adds or replaces an entry in a glossary in your Lara Translate account. Supports both monodirectional and multidirectional glossaries.",
+        inputSchema: z.toJSONSchema(addGlossaryEntrySchema),
+      },
+      {
+        name: "delete_glossary_entry",
+        description:
+          "Deletes an entry from a glossary in your Lara Translate account. Use term for monodirectional glossaries or guid for multidirectional glossaries.",
+        inputSchema: z.toJSONSchema(deleteGlossaryEntrySchema),
       },
     ],
   };

--- a/src/mcp/tools/add_glossary_entry.ts
+++ b/src/mcp/tools/add_glossary_entry.ts
@@ -1,0 +1,29 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const addGlossaryEntrySchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID (format: gls_*, e.g., 'gls_xyz123')"),
+  terms: z.array(z.object({
+    language: z.string().describe("The language code of the term. Use the list_languages tool to get supported languages."),
+    value: z.string().describe("The term value in the specified language"),
+  })).min(1).describe(
+    "Array of terms with language and value. For monodirectional glossaries, the first term is the source and the rest are targets. For multidirectional glossaries, all terms are treated equally. Use the list_languages tool to get supported language codes."
+  ),
+  guid: z.string().optional().describe(
+    "Optional entry identifier. Use this for multidirectional glossaries or to update a specific entry."
+  ),
+});
+
+export async function addGlossaryEntry(args: unknown, lara: Translator) {
+  const { id, terms, guid } = addGlossaryEntrySchema.parse(args);
+
+  if (guid !== undefined) {
+    return await lara.glossaries.addOrReplaceEntry(id, terms, guid);
+  }
+
+  return await lara.glossaries.addOrReplaceEntry(id, terms);
+}

--- a/src/mcp/tools/delete_glossary_entry.ts
+++ b/src/mcp/tools/delete_glossary_entry.ts
@@ -1,0 +1,28 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import { InvalidInputError } from "#exception";
+
+export const deleteGlossaryEntrySchema = z.object({
+  id: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    .describe("The glossary ID (format: gls_*, e.g., 'gls_xyz123')"),
+  term: z.object({
+    language: z.string().describe("The language code of the term"),
+    value: z.string().describe("The term value"),
+  }).optional().describe("The term to delete. Use this for monodirectional glossaries."),
+  guid: z.string().optional().describe(
+    "The entry GUID to delete. Use this for multidirectional glossaries."
+  ),
+});
+
+export async function deleteGlossaryEntry(args: unknown, lara: Translator) {
+  const { id, term, guid } = deleteGlossaryEntrySchema.parse(args);
+
+  if (!term && !guid) {
+    throw new InvalidInputError("At least one of 'term' or 'guid' must be provided");
+  }
+
+  return await lara.glossaries.deleteEntry(id, term, guid);
+}


### PR DESCRIPTION
## New
- add_glossary_entry tool to add/replace entries in glossaries
- delete_glossary_entry tool to remove entries from glossaries
- Support for both monodirectional and multidirectional glossaries

## Changed
- Registered new tools in MCP tool handlers and ListTools
- Added addOrReplaceEntry and deleteEntry to test mocks