### PR TITLE
feat: add document translation tools

### DIFF
--- a/src/__tests__/tools/check_document_status.test.ts
+++ b/src/__tests__/tools/check_document_status.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkDocumentStatus, checkDocumentStatusSchema } from '../../mcp/tools/check_document_status.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+setupTranslatorMock();
+
+describe('checkDocumentStatusSchema', () => {
+  it('should validate valid input', () => {
+    expect(() => checkDocumentStatusSchema.parse({ id: 'doc_123' })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => checkDocumentStatusSchema.parse({})).toThrow();
+  });
+
+  it('should reject empty id', () => {
+    expect(() => checkDocumentStatusSchema.parse({ id: '' })).toThrow();
+  });
+});
+
+describe('checkDocumentStatus', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.documents.status = vi.fn().mockResolvedValue({
+      id: 'doc_123',
+      status: 'translating',
+      translatedChars: 500,
+      totalChars: 1000,
+    });
+  });
+
+  it('should call lara.documents.status with correct ID', async () => {
+    const result = await checkDocumentStatus({ id: 'doc_123' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.documents.status).toHaveBeenCalledWith('doc_123');
+    expect(result).toEqual({
+      id: 'doc_123',
+      status: 'translating',
+      translatedChars: 500,
+      totalChars: 1000,
+    });
+  });
+});

--- a/src/__tests__/tools/download_document.test.ts
+++ b/src/__tests__/tools/download_document.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { downloadDocument, downloadDocumentSchema } from '../../mcp/tools/download_document.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+setupTranslatorMock();
+
+describe('downloadDocumentSchema', () => {
+  it('should validate valid input with id only', () => {
+    expect(() => downloadDocumentSchema.parse({ id: 'doc_123' })).not.toThrow();
+  });
+
+  it('should validate valid input with output_format', () => {
+    expect(() => downloadDocumentSchema.parse({ id: 'doc_123', output_format: 'pdf' })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => downloadDocumentSchema.parse({})).toThrow();
+  });
+
+  it('should reject invalid output_format', () => {
+    expect(() => downloadDocumentSchema.parse({ id: 'doc_123', output_format: 'docx' })).toThrow();
+  });
+});
+
+describe('downloadDocument', () => {
+  let mockTranslator: MockTranslator;
+  const testContent = 'translated file content';
+  const testBuffer = Buffer.from(testContent);
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.documents.download = vi.fn().mockResolvedValue(testBuffer);
+  });
+
+  it('should call lara.documents.download with correct params', async () => {
+    const result = await downloadDocument({ id: 'doc_123' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.documents.download).toHaveBeenCalledWith('doc_123', {});
+    expect(result.content).toBe(testBuffer.toString('base64'));
+  });
+
+  it('should pass output_format option', async () => {
+    await downloadDocument({ id: 'doc_123', output_format: 'pdf' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.documents.download).toHaveBeenCalledWith('doc_123', { outputFormat: 'pdf' });
+  });
+
+  it('should return base64-encoded content', async () => {
+    const result = await downloadDocument({ id: 'doc_123' }, mockTranslator as any as Translator);
+
+    // Verify round-trip
+    const decoded = Buffer.from(result.content, 'base64').toString();
+    expect(decoded).toBe(testContent);
+  });
+});

--- a/src/__tests__/tools/translate_document.test.ts
+++ b/src/__tests__/tools/translate_document.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { translateDocument, translateDocumentSchema } from '../../mcp/tools/translate_document.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+setupTranslatorMock();
+
+const validBase64 = Buffer.from('hello world').toString('base64');
+
+describe('translateDocumentSchema', () => {
+  it('should validate valid input with required fields', () => {
+    const input = { file_content: validBase64, filename: 'doc.docx', target: 'it-IT' };
+    expect(() => translateDocumentSchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate valid input with all fields', () => {
+    const input = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      source: 'en-EN',
+      target: 'it-IT',
+      adapt_to: ['mem_123'],
+      glossaries: ['gls_abc123'],
+      no_trace: true,
+      style: 'fluid' as const,
+      password: 'secret',
+      extract_comments: true,
+      accept_revisions: false,
+      output_format: 'pdf' as const,
+    };
+    expect(() => translateDocumentSchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing required fields', () => {
+    expect(() => translateDocumentSchema.parse({})).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+      glossaries: ['bad'],
+    };
+    expect(() => translateDocumentSchema.parse(input)).toThrow();
+  });
+});
+
+describe('translateDocument', () => {
+  let mockTranslator: MockTranslator;
+  const translatedContent = 'translated content bytes';
+  const translatedBuffer = Buffer.from(translatedContent);
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.documents.translate = vi.fn().mockResolvedValue(translatedBuffer);
+  });
+
+  it('should call lara.documents.translate with correct parameters', async () => {
+    const args = {
+      file_content: validBase64,
+      filename: 'report.docx',
+      source: 'en-EN',
+      target: 'it-IT',
+    };
+
+    const result = await translateDocument(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.documents.translate).toHaveBeenCalledOnce();
+    const [filePath, filename, source, target] = mockTranslator.documents.translate.mock.calls[0];
+    expect(typeof filePath).toBe('string');
+    expect(filename).toBe('report.docx');
+    expect(source).toBe('en-EN');
+    expect(target).toBe('it-IT');
+
+    // Verify base64 round-trip
+    const decoded = Buffer.from(result.content, 'base64').toString();
+    expect(decoded).toBe(translatedContent);
+    expect(result.filename).toBe('report.docx');
+  });
+
+  it('should pass null source when omitted', async () => {
+    await translateDocument({
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+    }, mockTranslator as any as Translator);
+
+    const [, , source] = mockTranslator.documents.translate.mock.calls[0];
+    expect(source).toBeNull();
+  });
+
+  it('should build options with all optional fields', async () => {
+    await translateDocument({
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+      glossaries: ['gls_abc'],
+      style: 'creative',
+      output_format: 'pdf',
+      extract_comments: true,
+    }, mockTranslator as any as Translator);
+
+    const [, , , , options] = mockTranslator.documents.translate.mock.calls[0];
+    expect(options.glossaries).toEqual(['gls_abc']);
+    expect(options.style).toBe('creative');
+    expect(options.outputFormat).toBe('pdf');
+    expect(options.extractionParams).toEqual({ extractComments: true });
+  });
+
+  it('should throw InvalidInputError for content exceeding 20MB', async () => {
+    const largeContent = Buffer.alloc(21 * 1024 * 1024).toString('base64');
+
+    await expect(translateDocument({
+      file_content: largeContent,
+      filename: 'large.docx',
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('Document too large');
+  });
+
+  it('should clean up temp files even on error', async () => {
+    mockTranslator.documents.translate = vi.fn().mockRejectedValue(new Error('SDK error'));
+
+    await expect(translateDocument({
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('SDK error');
+  });
+});

--- a/src/__tests__/tools/upload_document.test.ts
+++ b/src/__tests__/tools/upload_document.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uploadDocument, uploadDocumentSchema } from '../../mcp/tools/upload_document.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+setupTranslatorMock();
+
+const validBase64 = Buffer.from('hello world').toString('base64');
+
+describe('uploadDocumentSchema', () => {
+  it('should validate valid input with required fields', () => {
+    const input = { file_content: validBase64, filename: 'doc.docx', target: 'it-IT' };
+    expect(() => uploadDocumentSchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate valid input with all optional fields', () => {
+    const input = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      source: 'en-EN',
+      target: 'it-IT',
+      adapt_to: ['mem_123'],
+      glossaries: ['gls_abc123'],
+      no_trace: true,
+      style: 'faithful' as const,
+      password: 'secret',
+      extract_comments: true,
+      accept_revisions: false,
+    };
+    expect(() => uploadDocumentSchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing file_content', () => {
+    expect(() => uploadDocumentSchema.parse({ filename: 'doc.docx', target: 'it-IT' })).toThrow();
+  });
+
+  it('should reject missing filename', () => {
+    expect(() => uploadDocumentSchema.parse({ file_content: validBase64, target: 'it-IT' })).toThrow();
+  });
+
+  it('should reject missing target', () => {
+    expect(() => uploadDocumentSchema.parse({ file_content: validBase64, filename: 'doc.docx' })).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+      glossaries: ['invalid_id'],
+    };
+    expect(() => uploadDocumentSchema.parse(input)).toThrow();
+  });
+
+  it('should reject more than 10 glossaries', () => {
+    const input = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+      glossaries: Array.from({ length: 11 }, (_, i) => `gls_id${i}`),
+    };
+    expect(() => uploadDocumentSchema.parse(input)).toThrow();
+  });
+});
+
+describe('uploadDocument', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.documents.upload = vi.fn().mockResolvedValue({
+      id: 'doc_123',
+      status: 'initialized',
+      filename: 'doc.docx',
+      target: 'it-IT',
+    });
+  });
+
+  it('should call lara.documents.upload with correct parameters', async () => {
+    const args = {
+      file_content: validBase64,
+      filename: 'report.docx',
+      source: 'en-EN',
+      target: 'it-IT',
+    };
+
+    const result = await uploadDocument(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.documents.upload).toHaveBeenCalledOnce();
+    const [filePath, filename, source, target, options] = mockTranslator.documents.upload.mock.calls[0];
+    expect(typeof filePath).toBe('string');
+    expect(filename).toBe('report.docx');
+    expect(source).toBe('en-EN');
+    expect(target).toBe('it-IT');
+    expect(result).toEqual({ id: 'doc_123', status: 'initialized', filename: 'doc.docx', target: 'it-IT' });
+  });
+
+  it('should pass null source when omitted', async () => {
+    const args = { file_content: validBase64, filename: 'doc.docx', target: 'it-IT' };
+    await uploadDocument(args, mockTranslator as any as Translator);
+
+    const [, , source] = mockTranslator.documents.upload.mock.calls[0];
+    expect(source).toBeNull();
+  });
+
+  it('should build options with glossaries and style', async () => {
+    const args = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+      glossaries: ['gls_abc'],
+      style: 'creative',
+    };
+
+    await uploadDocument(args, mockTranslator as any as Translator);
+    const [, , , , options] = mockTranslator.documents.upload.mock.calls[0];
+    expect(options.glossaries).toEqual(['gls_abc']);
+    expect(options.style).toBe('creative');
+  });
+
+  it('should build extractionParams for DOCX options', async () => {
+    const args = {
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+      extract_comments: true,
+      accept_revisions: true,
+    };
+
+    await uploadDocument(args, mockTranslator as any as Translator);
+    const [, , , , options] = mockTranslator.documents.upload.mock.calls[0];
+    expect(options.extractionParams).toEqual({ extractComments: true, acceptRevisions: true });
+  });
+
+  it('should throw InvalidInputError for content exceeding 20MB', async () => {
+    const largeContent = Buffer.alloc(21 * 1024 * 1024).toString('base64');
+
+    await expect(uploadDocument({
+      file_content: largeContent,
+      filename: 'large.docx',
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('Document too large');
+  });
+
+  it('should clean up temp files even on error', async () => {
+    mockTranslator.documents.upload = vi.fn().mockRejectedValue(new Error('SDK error'));
+
+    await expect(uploadDocument({
+      file_content: validBase64,
+      filename: 'doc.docx',
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('SDK error');
+  });
+});

--- a/src/__tests__/tools/upload_document.test.ts
+++ b/src/__tests__/tools/upload_document.test.ts
@@ -79,7 +79,7 @@ describe('uploadDocument', () => {
   it('should call lara.documents.upload with correct parameters', async () => {
     const args = {
       file_content: validBase64,
-      filename: 'report.docx',
+      filename: 'doc.docx',
       source: 'en-EN',
       target: 'it-IT',
     };
@@ -89,7 +89,7 @@ describe('uploadDocument', () => {
     expect(mockTranslator.documents.upload).toHaveBeenCalledOnce();
     const [filePath, filename, source, target, options] = mockTranslator.documents.upload.mock.calls[0];
     expect(typeof filePath).toBe('string');
-    expect(filename).toBe('report.docx');
+    expect(filename).toBe('doc.docx');
     expect(source).toBe('en-EN');
     expect(target).toBe('it-IT');
     expect(result).toEqual({ id: 'doc_123', status: 'initialized', filename: 'doc.docx', target: 'it-IT' });

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -45,6 +45,12 @@ export function createMockTranslator() {
       addOrReplaceEntry: vi.fn(),
       deleteEntry: vi.fn(),
     },
+    documents: {
+      upload: vi.fn(),
+      status: vi.fn(),
+      download: vi.fn(),
+      translate: vi.fn(),
+    },
     client: {}
   };
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -34,6 +34,10 @@ import { getGlossaryCounts, getGlossaryCountsSchema } from "./tools/get_glossary
 import { addGlossaryEntry, addGlossaryEntrySchema } from "./tools/add_glossary_entry.js";
 import { deleteGlossaryEntry, deleteGlossaryEntrySchema } from "./tools/delete_glossary_entry.js";
 import { translateHandler, translateSchema } from "./tools/translate.js";
+import { uploadDocument, uploadDocumentSchema } from "./tools/upload_document.js";
+import { checkDocumentStatus, checkDocumentStatusSchema } from "./tools/check_document_status.js";
+import { downloadDocument, downloadDocumentSchema } from "./tools/download_document.js";
+import { translateDocument, translateDocumentSchema } from "./tools/translate_document.js";
 import {
   updateMemory,
   updateMemorySchema,
@@ -63,6 +67,10 @@ const handlers: Record<string, Handler> = {
   get_glossary_counts: getGlossaryCounts,
   add_glossary_entry: addGlossaryEntry,
   delete_glossary_entry: deleteGlossaryEntry,
+  upload_document: uploadDocument,
+  check_document_status: checkDocumentStatus,
+  download_document: downloadDocument,
+  translate_document: translateDocument,
 };
 
 const listers: Record<string, Lister> = {
@@ -256,6 +264,30 @@ async function ListTools() {
         description:
           "Deletes an entry from a glossary in your Lara Translate account. Use term for monodirectional glossaries or guid for multidirectional glossaries.",
         inputSchema: z.toJSONSchema(deleteGlossaryEntrySchema),
+      },
+      {
+        name: "upload_document",
+        description:
+          "Uploads a document (DOCX, PDF, etc.) for translation in your Lara Translate account. Returns a document object with an ID that can be used to check status and download the result.",
+        inputSchema: z.toJSONSchema(uploadDocumentSchema),
+      },
+      {
+        name: "check_document_status",
+        description:
+          "Checks the translation status and progress of a previously uploaded document in your Lara Translate account.",
+        inputSchema: z.toJSONSchema(checkDocumentStatusSchema),
+      },
+      {
+        name: "download_document",
+        description:
+          "Downloads a translated document from your Lara Translate account. Returns the document as base64-encoded content.",
+        inputSchema: z.toJSONSchema(downloadDocumentSchema),
+      },
+      {
+        name: "translate_document",
+        description:
+          "All-in-one document translation: uploads a document, waits for translation to complete, and returns the translated document as base64-encoded content.",
+        inputSchema: z.toJSONSchema(translateDocumentSchema),
       },
     ],
   };

--- a/src/mcp/tools/check_document_status.ts
+++ b/src/mcp/tools/check_document_status.ts
@@ -1,0 +1,14 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const checkDocumentStatusSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .describe("The document ID to check status for."),
+});
+
+export async function checkDocumentStatus(args: unknown, lara: Translator) {
+  const validatedArgs = checkDocumentStatusSchema.parse(args);
+  return await lara.documents.status(validatedArgs.id);
+}

--- a/src/mcp/tools/download_document.ts
+++ b/src/mcp/tools/download_document.ts
@@ -1,0 +1,30 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import { resultToBase64 } from "./upload_document.js";
+
+export const downloadDocumentSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .describe("The document ID to download."),
+  output_format: z
+    .enum(["pdf"])
+    .optional()
+    .describe("Output format. Only applicable for PDF source files."),
+});
+
+export async function downloadDocument(args: unknown, lara: Translator) {
+  const validatedArgs = downloadDocumentSchema.parse(args);
+  const { id, output_format } = validatedArgs;
+
+  const options: Record<string, unknown> = {};
+  if (typeof output_format !== "undefined") {
+    options.outputFormat = output_format;
+  }
+
+  const result = await lara.documents.download(id, options);
+
+  return {
+    content: await resultToBase64(result),
+  };
+}

--- a/src/mcp/tools/translate_document.ts
+++ b/src/mcp/tools/translate_document.ts
@@ -1,0 +1,44 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  uploadDocumentSchema,
+  buildDocumentOptions,
+  decodeAndValidateBase64,
+  resultToBase64,
+} from "./upload_document.js";
+
+export const translateDocumentSchema = uploadDocumentSchema.extend({
+  output_format: z
+    .enum(["pdf"])
+    .optional()
+    .describe("Output format. Only applicable for PDF source files."),
+});
+
+export async function translateDocument(args: unknown, lara: Translator) {
+  const validatedArgs = translateDocumentSchema.parse(args);
+  const { file_content, filename, source, target } = validatedArgs;
+
+  const fileBuffer = decodeAndValidateBase64(file_content);
+  const safeName = path.basename(filename);
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-doc-"));
+  const tempFilePath = path.join(tempDir, safeName);
+
+  try {
+    fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });
+    const options = buildDocumentOptions(validatedArgs);
+    const result = await lara.documents.translate(tempFilePath, filename, source ?? null, target, options);
+
+    return {
+      content: await resultToBase64(result),
+      filename: filename,
+    };
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (_) { /* best-effort cleanup */ }
+  }
+}

--- a/src/mcp/tools/translate_document.ts
+++ b/src/mcp/tools/translate_document.ts
@@ -22,10 +22,9 @@ export async function translateDocument(args: unknown, lara: Translator) {
   const { file_content, filename, source, target } = validatedArgs;
 
   const fileBuffer = decodeAndValidateBase64(file_content);
-  const safeName = path.basename(filename);
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-doc-"));
-  const tempFilePath = path.join(tempDir, safeName);
+  const tempFilePath = path.join(tempDir, "upload");
 
   try {
     fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });

--- a/src/mcp/tools/upload_document.ts
+++ b/src/mcp/tools/upload_document.ts
@@ -127,10 +127,9 @@ export async function uploadDocument(args: unknown, lara: Translator) {
   const { file_content, filename, source, target } = validatedArgs;
 
   const fileBuffer = decodeAndValidateBase64(file_content);
-  const safeName = path.basename(filename);
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-doc-"));
-  const tempFilePath = path.join(tempDir, safeName);
+  const tempFilePath = path.join(tempDir, "upload");
 
   try {
     fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });

--- a/src/mcp/tools/upload_document.ts
+++ b/src/mcp/tools/upload_document.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import { InvalidInputError } from "#exception";
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
-const MAX_BASE64_LENGTH = Math.ceil(MAX_FILE_SIZE * 4 / 3);
+const MAX_BASE64_LENGTH = 4 * Math.ceil(MAX_FILE_SIZE / 3);
 
 export const uploadDocumentSchema = z.object({
   file_content: z
@@ -108,7 +108,11 @@ export function decodeAndValidateBase64(file_content: string): Buffer {
   if (file_content.length > MAX_BASE64_LENGTH) {
     throw new InvalidInputError("Document too large. Maximum allowed size is 20MB.");
   }
-  return Buffer.from(file_content, "base64");
+  const buffer = Buffer.from(file_content, "base64");
+  if (buffer.length > MAX_FILE_SIZE) {
+    throw new InvalidInputError("Document too large. Maximum allowed size is 20MB.");
+  }
+  return buffer;
 }
 
 export function resultToBase64(result: Buffer | Blob): Promise<string> | string {

--- a/src/mcp/tools/upload_document.ts
+++ b/src/mcp/tools/upload_document.ts
@@ -1,0 +1,140 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { InvalidInputError } from "#exception";
+
+const MAX_FILE_SIZE = 20 * 1024 * 1024;
+const MAX_BASE64_LENGTH = Math.ceil(MAX_FILE_SIZE * 4 / 3);
+
+export const uploadDocumentSchema = z.object({
+  file_content: z
+    .string()
+    .describe("Base64-encoded file content of the document to translate."),
+  filename: z
+    .string()
+    .min(1)
+    .describe("Original filename with extension (e.g., 'report.docx'). Used for format detection."),
+  source: z
+    .string()
+    .optional()
+    .describe("Source language code (e.g., 'en-EN'). Auto-detected if omitted."),
+  target: z
+    .string()
+    .describe("Target language code (e.g., 'it-IT')."),
+  adapt_to: z
+    .array(z.string())
+    .optional()
+    .describe("A list of translation memory IDs for adapting the translation."),
+  glossaries: z
+    .array(
+      z.string()
+        .min(1)
+        .max(255)
+        .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    )
+    .max(10)
+    .optional()
+    .describe("Array of glossary IDs to apply during translation (max 10). IDs must match format: gls_*."),
+  no_trace: z
+    .boolean()
+    .optional()
+    .describe("Privacy flag. If true, the request will not be traced or logged."),
+  style: z
+    .enum(["faithful", "fluid", "creative"])
+    .optional()
+    .describe("Controls how the translation balances accuracy against natural readability."),
+  password: z
+    .string()
+    .optional()
+    .describe("Password for password-protected PDF files."),
+  extract_comments: z
+    .boolean()
+    .optional()
+    .describe("DOCX: extract comments for translation."),
+  accept_revisions: z
+    .boolean()
+    .optional()
+    .describe("DOCX: accept tracked revisions before translating."),
+});
+
+export function buildDocumentOptions(args: {
+  adapt_to?: string[];
+  glossaries?: string[];
+  no_trace?: boolean;
+  style?: string;
+  password?: string;
+  extract_comments?: boolean;
+  accept_revisions?: boolean;
+  output_format?: string;
+}): Record<string, unknown> {
+  const options: Record<string, unknown> = {};
+
+  if (typeof args.adapt_to !== "undefined") {
+    options.adaptTo = args.adapt_to;
+  }
+  if (typeof args.glossaries !== "undefined") {
+    options.glossaries = args.glossaries;
+  }
+  if (typeof args.no_trace !== "undefined") {
+    options.noTrace = args.no_trace;
+  }
+  if (typeof args.style !== "undefined") {
+    options.style = args.style;
+  }
+  if (typeof args.password !== "undefined") {
+    options.password = args.password;
+  }
+  if (typeof args.output_format !== "undefined") {
+    options.outputFormat = args.output_format;
+  }
+
+  const extractionParams: Record<string, boolean> = {};
+  if (typeof args.extract_comments !== "undefined") {
+    extractionParams.extractComments = args.extract_comments;
+  }
+  if (typeof args.accept_revisions !== "undefined") {
+    extractionParams.acceptRevisions = args.accept_revisions;
+  }
+  if (Object.keys(extractionParams).length > 0) {
+    options.extractionParams = extractionParams;
+  }
+
+  return options;
+}
+
+export function decodeAndValidateBase64(file_content: string): Buffer {
+  if (file_content.length > MAX_BASE64_LENGTH) {
+    throw new InvalidInputError("Document too large. Maximum allowed size is 20MB.");
+  }
+  return Buffer.from(file_content, "base64");
+}
+
+export function resultToBase64(result: Buffer | Blob): Promise<string> | string {
+  if (Buffer.isBuffer(result)) {
+    return result.toString("base64");
+  }
+  return (result as Blob).arrayBuffer().then(ab => Buffer.from(ab).toString("base64"));
+}
+
+export async function uploadDocument(args: unknown, lara: Translator) {
+  const validatedArgs = uploadDocumentSchema.parse(args);
+  const { file_content, filename, source, target } = validatedArgs;
+
+  const fileBuffer = decodeAndValidateBase64(file_content);
+  const safeName = path.basename(filename);
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-doc-"));
+  const tempFilePath = path.join(tempDir, safeName);
+
+  try {
+    fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });
+    const options = buildDocumentOptions(validatedArgs);
+    return await lara.documents.upload(tempFilePath, filename, source ?? null, target, options);
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (_) { /* best-effort cleanup */ }
+  }
+}


### PR DESCRIPTION
## New
- upload_document tool to upload documents (DOCX, PDF, etc.) for translation
- check_document_status tool to check translation progress
- download_document tool to download translated documents as base64
- translate_document tool for all-in-one upload, translate, and download
- Shared helpers for base64 validation, options building, and result encoding
- Path traversal protection via filename sanitization
- Early size rejection before base64 decoding (20MB limit)
- Tests for all four new tools (33 tests)