### PR TITLE
feat: add audio translation tools

### DIFF
--- a/src/__tests__/tools/check_audio_translation_status.test.ts
+++ b/src/__tests__/tools/check_audio_translation_status.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkAudioTranslationStatus, checkAudioTranslationStatusSchema } from '../../mcp/tools/check_audio_translation_status.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('checkAudioTranslationStatusSchema', () => {
+  it('should validate valid input', () => {
+    expect(() => checkAudioTranslationStatusSchema.parse({ id: 'audio_123' })).not.toThrow();
+  });
+
+  it('should reject input with missing id', () => {
+    expect(() => checkAudioTranslationStatusSchema.parse({})).toThrow();
+  });
+});
+
+describe('checkAudioTranslationStatus', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should call lara.audio.status with correct ID', async () => {
+    const mockResult = {
+      id: 'audio_123',
+      status: 'translating',
+      translatedSeconds: 30,
+      totalSeconds: 120,
+      target: 'it-IT',
+      filename: 'audio.mp3',
+    };
+    mockTranslator.audio.status.mockResolvedValue(mockResult);
+
+    const result = await checkAudioTranslationStatus(
+      { id: 'audio_123' },
+      mockTranslator as any as Translator
+    );
+
+    expect(mockTranslator.audio.status).toHaveBeenCalledWith('audio_123');
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/tools/download_translated_audio.test.ts
+++ b/src/__tests__/tools/download_translated_audio.test.ts
@@ -41,6 +41,20 @@ describe('downloadTranslatedAudioSchema', () => {
       id: 'audio_123',
     })).toThrow();
   });
+
+  it('should reject relative output_path', () => {
+    expect(() => downloadTranslatedAudioSchema.parse({
+      id: 'audio_123',
+      output_path: 'relative/translated.mp3',
+    })).toThrow();
+  });
+
+  it('should reject output_path with ".." segments', () => {
+    expect(() => downloadTranslatedAudioSchema.parse({
+      id: 'audio_123',
+      output_path: '/tmp/../etc/translated.mp3',
+    })).toThrow();
+  });
 });
 
 describe('downloadTranslatedAudio', () => {

--- a/src/__tests__/tools/download_translated_audio.test.ts
+++ b/src/__tests__/tools/download_translated_audio.test.ts
@@ -14,6 +14,7 @@ vi.mock('fs', async () => {
     ...actual,
     accessSync: vi.fn(),
     createWriteStream: vi.fn(),
+    renameSync: vi.fn(),
     unlinkSync: vi.fn(),
   };
 });
@@ -61,14 +62,16 @@ describe('downloadTranslatedAudio', () => {
   let mockTranslator: MockTranslator;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     mockTranslator = getMockTranslator();
     vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+    vi.mocked(fs.renameSync).mockImplementation(() => undefined);
 
     const { pipeline } = await import('stream/promises');
     vi.mocked(pipeline).mockResolvedValue(undefined);
   });
 
-  it('should download and save audio file', async () => {
+  it('should download and save audio file via temp file', async () => {
     const mockStream = new PassThrough();
     mockTranslator.audio.download.mockResolvedValue(mockStream);
 
@@ -81,6 +84,12 @@ describe('downloadTranslatedAudio', () => {
     );
 
     expect(mockTranslator.audio.download).toHaveBeenCalledWith('audio_123');
+    // Should write to a temp file, then rename
+    expect(fs.createWriteStream).toHaveBeenCalledWith(expect.stringMatching(/^\/tmp\/\.lara-download-[a-f0-9]+\.tmp$/));
+    expect(fs.renameSync).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/tmp\/\.lara-download-[a-f0-9]+\.tmp$/),
+      '/tmp/translated.mp3'
+    );
     expect(result).toEqual({
       output_path: '/tmp/translated.mp3',
       message: 'Translated audio saved successfully.',
@@ -100,7 +109,7 @@ describe('downloadTranslatedAudio', () => {
     ).rejects.toThrow('Output directory not found or not writable');
   });
 
-  it('should clean up partial file on pipeline error', async () => {
+  it('should clean up temp file on pipeline error without deleting target', async () => {
     const mockStream = new PassThrough();
     mockTranslator.audio.download.mockResolvedValue(mockStream);
 
@@ -117,6 +126,9 @@ describe('downloadTranslatedAudio', () => {
       )
     ).rejects.toThrow('Stream error');
 
-    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/translated.mp3');
+    // Should clean up the temp file, not the target path
+    expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringMatching(/^\/tmp\/\.lara-download-[a-f0-9]+\.tmp$/));
+    expect(fs.unlinkSync).not.toHaveBeenCalledWith('/tmp/translated.mp3');
+    expect(fs.renameSync).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/tools/download_translated_audio.test.ts
+++ b/src/__tests__/tools/download_translated_audio.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { downloadTranslatedAudio, downloadTranslatedAudioSchema } from '../../mcp/tools/download_translated_audio.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+import * as fs from 'fs';
+import { PassThrough } from 'stream';
+
+// Setup mocks
+setupTranslatorMock();
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof fs>('fs');
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+    createWriteStream: vi.fn(),
+    unlinkSync: vi.fn(),
+  };
+});
+
+vi.mock('stream/promises', () => ({
+  pipeline: vi.fn(),
+}));
+
+describe('downloadTranslatedAudioSchema', () => {
+  it('should validate valid input', () => {
+    expect(() => downloadTranslatedAudioSchema.parse({
+      id: 'audio_123',
+      output_path: '/tmp/translated.mp3',
+    })).not.toThrow();
+  });
+
+  it('should reject missing id', () => {
+    expect(() => downloadTranslatedAudioSchema.parse({
+      output_path: '/tmp/translated.mp3',
+    })).toThrow();
+  });
+
+  it('should reject missing output_path', () => {
+    expect(() => downloadTranslatedAudioSchema.parse({
+      id: 'audio_123',
+    })).toThrow();
+  });
+});
+
+describe('downloadTranslatedAudio', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(async () => {
+    mockTranslator = getMockTranslator();
+    vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+
+    const { pipeline } = await import('stream/promises');
+    vi.mocked(pipeline).mockResolvedValue(undefined);
+  });
+
+  it('should download and save audio file', async () => {
+    const mockStream = new PassThrough();
+    mockTranslator.audio.download.mockResolvedValue(mockStream);
+
+    const mockWriteStream = new PassThrough();
+    vi.mocked(fs.createWriteStream).mockReturnValue(mockWriteStream as any);
+
+    const result = await downloadTranslatedAudio(
+      { id: 'audio_123', output_path: '/tmp/translated.mp3' },
+      mockTranslator as any as Translator
+    );
+
+    expect(mockTranslator.audio.download).toHaveBeenCalledWith('audio_123');
+    expect(result).toEqual({
+      output_path: '/tmp/translated.mp3',
+      message: 'Translated audio saved successfully.',
+    });
+  });
+
+  it('should throw on unwritable output directory', async () => {
+    vi.mocked(fs.accessSync).mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    await expect(
+      downloadTranslatedAudio(
+        { id: 'audio_123', output_path: '/readonly/translated.mp3' },
+        mockTranslator as any as Translator
+      )
+    ).rejects.toThrow('Output directory not found or not writable');
+  });
+
+  it('should clean up partial file on pipeline error', async () => {
+    const mockStream = new PassThrough();
+    mockTranslator.audio.download.mockResolvedValue(mockStream);
+
+    const mockWriteStream = new PassThrough();
+    vi.mocked(fs.createWriteStream).mockReturnValue(mockWriteStream as any);
+
+    const { pipeline } = await import('stream/promises');
+    vi.mocked(pipeline).mockRejectedValue(new Error('Stream error'));
+
+    await expect(
+      downloadTranslatedAudio(
+        { id: 'audio_123', output_path: '/tmp/translated.mp3' },
+        mockTranslator as any as Translator
+      )
+    ).rejects.toThrow('Stream error');
+
+    expect(fs.unlinkSync).toHaveBeenCalledWith('/tmp/translated.mp3');
+  });
+});

--- a/src/__tests__/tools/translate_audio.test.ts
+++ b/src/__tests__/tools/translate_audio.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { translateAudio, translateAudioSchema } from '../../mcp/tools/translate_audio.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+import * as fs from 'fs';
+
+// Setup mocks
+setupTranslatorMock();
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof fs>('fs');
+  return {
+    ...actual,
+    accessSync: vi.fn(),
+  };
+});
+
+describe('translateAudioSchema', () => {
+  it('should validate valid input with all fields', () => {
+    const input = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      source: 'en-EN',
+      adapt_to: ['mem_123'],
+      glossaries: ['gls_abc123'],
+      no_trace: true,
+      style: 'faithful',
+      voice_gender: 'female',
+    };
+
+    expect(() => translateAudioSchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate valid input with only required fields', () => {
+    const input = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+    };
+
+    expect(() => translateAudioSchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing file_path', () => {
+    const input = { target: 'it-IT' };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject missing target', () => {
+    const input = { file_path: '/tmp/audio.mp3' };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      glossaries: ['invalid_id'],
+    };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject more than 10 glossaries', () => {
+    const input = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      glossaries: Array.from({ length: 11 }, (_, i) => `gls_id${i}`),
+    };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject invalid style value', () => {
+    const input = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      style: 'invalid',
+    };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject invalid voice_gender value', () => {
+    const input = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      voice_gender: 'other',
+    };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+});
+
+describe('translateAudio', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    vi.mocked(fs.accessSync).mockImplementation(() => undefined);
+  });
+
+  it('should call lara.audio.upload with correct args', async () => {
+    const mockResult = {
+      id: 'audio_123',
+      status: 'initialized',
+      target: 'it-IT',
+      filename: 'audio.mp3',
+    };
+    mockTranslator.audio.upload.mockResolvedValue(mockResult);
+
+    const args = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      source: 'en-EN',
+    };
+
+    const result = await translateAudio(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.audio.upload).toHaveBeenCalledWith(
+      '/tmp/audio.mp3',
+      'audio.mp3',
+      'en-EN',
+      'it-IT',
+      {}
+    );
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should pass source as null when not provided', async () => {
+    const mockResult = { id: 'audio_123', status: 'initialized', target: 'it-IT', filename: 'audio.mp3' };
+    mockTranslator.audio.upload.mockResolvedValue(mockResult);
+
+    await translateAudio({ file_path: '/tmp/audio.mp3', target: 'it-IT' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.audio.upload).toHaveBeenCalledWith(
+      '/tmp/audio.mp3',
+      'audio.mp3',
+      null,
+      'it-IT',
+      {}
+    );
+  });
+
+  it('should build options only with defined values', async () => {
+    mockTranslator.audio.upload.mockResolvedValue({ id: 'audio_123' });
+
+    const args = {
+      file_path: '/tmp/audio.mp3',
+      target: 'it-IT',
+      glossaries: ['gls_abc'],
+      style: 'fluid',
+      voice_gender: 'male',
+      no_trace: true,
+      adapt_to: ['mem_1'],
+    };
+
+    await translateAudio(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.audio.upload).toHaveBeenCalledWith(
+      '/tmp/audio.mp3',
+      'audio.mp3',
+      null,
+      'it-IT',
+      {
+        glossaries: ['gls_abc'],
+        style: 'fluid',
+        voiceGender: 'male',
+        noTrace: true,
+        adaptTo: ['mem_1'],
+      }
+    );
+  });
+
+  it('should throw on unreadable file', async () => {
+    vi.mocked(fs.accessSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    await expect(
+      translateAudio({ file_path: '/nonexistent/file.mp3', target: 'it-IT' }, mockTranslator as any as Translator)
+    ).rejects.toThrow('File not found or not readable');
+  });
+});

--- a/src/__tests__/tools/translate_audio.test.ts
+++ b/src/__tests__/tools/translate_audio.test.ts
@@ -85,6 +85,22 @@ describe('translateAudioSchema', () => {
     };
     expect(() => translateAudioSchema.parse(input)).toThrow();
   });
+
+  it('should reject relative file_path', () => {
+    const input = {
+      file_path: 'relative/audio.mp3',
+      target: 'it-IT',
+    };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject file_path with ".." segments', () => {
+    const input = {
+      file_path: '/tmp/../etc/passwd',
+      target: 'it-IT',
+    };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
 });
 
 describe('translateAudio', () => {

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -45,6 +45,12 @@ export function createMockTranslator() {
       addOrReplaceEntry: vi.fn(),
       deleteEntry: vi.fn(),
     },
+    audio: {
+      upload: vi.fn(),
+      status: vi.fn(),
+      download: vi.fn(),
+      translate: vi.fn(),
+    },
     client: {}
   };
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -34,6 +34,9 @@ import { getGlossaryCounts, getGlossaryCountsSchema } from "./tools/get_glossary
 import { addGlossaryEntry, addGlossaryEntrySchema } from "./tools/add_glossary_entry.js";
 import { deleteGlossaryEntry, deleteGlossaryEntrySchema } from "./tools/delete_glossary_entry.js";
 import { translateHandler, translateSchema } from "./tools/translate.js";
+import { translateAudio, translateAudioSchema } from "./tools/translate_audio.js";
+import { checkAudioTranslationStatus, checkAudioTranslationStatusSchema } from "./tools/check_audio_translation_status.js";
+import { downloadTranslatedAudio, downloadTranslatedAudioSchema } from "./tools/download_translated_audio.js";
 import {
   updateMemory,
   updateMemorySchema,
@@ -63,6 +66,9 @@ const handlers: Record<string, Handler> = {
   get_glossary_counts: getGlossaryCounts,
   add_glossary_entry: addGlossaryEntry,
   delete_glossary_entry: deleteGlossaryEntry,
+  translate_audio: translateAudio,
+  check_audio_translation_status: checkAudioTranslationStatus,
+  download_translated_audio: downloadTranslatedAudio,
 };
 
 const listers: Record<string, Lister> = {
@@ -256,6 +262,24 @@ async function ListTools() {
         description:
           "Deletes an entry from a glossary in your Lara Translate account. Use term for monodirectional glossaries or guid for multidirectional glossaries.",
         inputSchema: z.toJSONSchema(deleteGlossaryEntrySchema),
+      },
+      {
+        name: "translate_audio",
+        description:
+          "Step 1 of 3 for audio translation. Uploads an audio file and starts an asynchronous translation job. The job may take minutes to complete. After calling this tool, use check_audio_translation_status to poll until status is 'translated', then use download_translated_audio to save the result.",
+        inputSchema: z.toJSONSchema(translateAudioSchema),
+      },
+      {
+        name: "check_audio_translation_status",
+        description:
+          "Step 2 of 3 for audio translation. Polls the status of an audio translation job started with translate_audio. Keep polling until status is 'translated' (success) or 'error' (failure). Possible statuses: initialized, analyzing, paused, ready, translating, translated, error.",
+        inputSchema: z.toJSONSchema(checkAudioTranslationStatusSchema),
+      },
+      {
+        name: "download_translated_audio",
+        description:
+          "Step 3 of 3 for audio translation. Downloads the translated audio file to disk. Only call this after check_audio_translation_status returns status 'translated'. Requires the job id from translate_audio and an output_path where the file will be saved.",
+        inputSchema: z.toJSONSchema(downloadTranslatedAudioSchema),
       },
     ],
   };

--- a/src/mcp/tools/check_audio_translation_status.ts
+++ b/src/mcp/tools/check_audio_translation_status.ts
@@ -1,0 +1,13 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const checkAudioTranslationStatusSchema = z.object({
+  id: z.string().describe("The ID of the audio translation job returned by translate_audio."),
+});
+
+export async function checkAudioTranslationStatus(args: unknown, lara: Translator) {
+  const validatedArgs = checkAudioTranslationStatusSchema.parse(args);
+  const { id } = validatedArgs;
+
+  return await lara.audio.status(id);
+}

--- a/src/mcp/tools/download_translated_audio.ts
+++ b/src/mcp/tools/download_translated_audio.ts
@@ -1,0 +1,42 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import * as fs from "fs";
+import * as path from "path";
+import { pipeline } from "stream/promises";
+import { InvalidInputError } from "#exception";
+
+export const downloadTranslatedAudioSchema = z.object({
+  id: z.string().describe("The ID of the audio translation job returned by translate_audio."),
+  output_path: z
+    .string()
+    .describe(
+      "The absolute path where the translated audio file will be saved."
+    ),
+});
+
+export async function downloadTranslatedAudio(args: unknown, lara: Translator) {
+  const validatedArgs = downloadTranslatedAudioSchema.parse(args);
+  const { id, output_path } = validatedArgs;
+
+  // Validate output directory exists and is writable
+  const outputDir = path.dirname(output_path);
+  try {
+    fs.accessSync(outputDir, fs.constants.W_OK);
+  } catch {
+    throw new InvalidInputError(`Output directory not found or not writable: ${outputDir}`);
+  }
+
+  const readable = await lara.audio.download(id);
+
+  try {
+    await pipeline(readable, fs.createWriteStream(output_path));
+  } catch (error) {
+    // Best-effort cleanup of partial file
+    try {
+      fs.unlinkSync(output_path);
+    } catch { /* ignore cleanup errors */ }
+    throw error;
+  }
+
+  return { output_path, message: "Translated audio saved successfully." };
+}

--- a/src/mcp/tools/download_translated_audio.ts
+++ b/src/mcp/tools/download_translated_audio.ts
@@ -1,5 +1,6 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import { pipeline } from "stream/promises";
@@ -38,12 +39,17 @@ export async function downloadTranslatedAudio(args: unknown, lara: Translator) {
 
   const readable = await lara.audio.download(id);
 
+  // Write to a temp file first, then atomically rename to avoid
+  // destroying a pre-existing file on transient download errors.
+  const tempPath = path.join(outputDir, `.lara-download-${crypto.randomBytes(8).toString('hex')}.tmp`);
+
   try {
-    await pipeline(readable, fs.createWriteStream(normalizedOutputPath));
+    await pipeline(readable, fs.createWriteStream(tempPath));
+    fs.renameSync(tempPath, normalizedOutputPath);
   } catch (error) {
-    // Best-effort cleanup of partial file
+    // Best-effort cleanup of temp file only
     try {
-      fs.unlinkSync(normalizedOutputPath);
+      fs.unlinkSync(tempPath);
     } catch { /* ignore cleanup errors */ }
     throw error;
   }

--- a/src/mcp/tools/download_translated_audio.ts
+++ b/src/mcp/tools/download_translated_audio.ts
@@ -9,6 +9,14 @@ export const downloadTranslatedAudioSchema = z.object({
   id: z.string().describe("The ID of the audio translation job returned by translate_audio."),
   output_path: z
     .string()
+    .refine(
+      (p) => path.isAbsolute(p),
+      "output_path must be an absolute path",
+    )
+    .refine(
+      (p) => !/(^|[\\/])\.\.([\\/]|$)/.test(p),
+      'output_path must not contain ".." path segments',
+    )
     .describe(
       "The absolute path where the translated audio file will be saved."
     ),
@@ -18,8 +26,10 @@ export async function downloadTranslatedAudio(args: unknown, lara: Translator) {
   const validatedArgs = downloadTranslatedAudioSchema.parse(args);
   const { id, output_path } = validatedArgs;
 
+  const normalizedOutputPath = path.normalize(output_path);
+
   // Validate output directory exists and is writable
-  const outputDir = path.dirname(output_path);
+  const outputDir = path.dirname(normalizedOutputPath);
   try {
     fs.accessSync(outputDir, fs.constants.W_OK);
   } catch {
@@ -29,14 +39,14 @@ export async function downloadTranslatedAudio(args: unknown, lara: Translator) {
   const readable = await lara.audio.download(id);
 
   try {
-    await pipeline(readable, fs.createWriteStream(output_path));
+    await pipeline(readable, fs.createWriteStream(normalizedOutputPath));
   } catch (error) {
     // Best-effort cleanup of partial file
     try {
-      fs.unlinkSync(output_path);
+      fs.unlinkSync(normalizedOutputPath);
     } catch { /* ignore cleanup errors */ }
     throw error;
   }
 
-  return { output_path, message: "Translated audio saved successfully." };
+  return { output_path: normalizedOutputPath, message: "Translated audio saved successfully." };
 }

--- a/src/mcp/tools/translate.ts
+++ b/src/mcp/tools/translate.ts
@@ -64,7 +64,7 @@ export const translateSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "Privacy flag. If set to true, the translation request will not be traced or logged. Use for sensitive content."
+      "Privacy flag. If set to true, the request content will not be stored or traced by Lara. Use for sensitive content."
     ),
   priority: z
     .enum(["normal", "background"])

--- a/src/mcp/tools/translate_audio.ts
+++ b/src/mcp/tools/translate_audio.ts
@@ -1,0 +1,114 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import * as fs from "fs";
+import * as path from "path";
+import { logger } from "#logger";
+import { InvalidInputError } from "#exception";
+
+export const translateAudioSchema = z.object({
+  file_path: z
+    .string()
+    .describe(
+      "The absolute path to the audio file to translate."
+    ),
+  target: z
+    .string()
+    .describe(
+      "The target language code (e.g., 'it-IT' for Italian)."
+    ),
+  source: z
+    .string()
+    .optional()
+    .describe(
+      "The source language code. If not specified, the system will attempt to detect it automatically."
+    ),
+  adapt_to: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "A list of translation memory IDs for adapting the translation."
+    ),
+  glossaries: z
+    .array(
+      z.string()
+        .min(1)
+        .max(255)
+        .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    )
+    .max(10)
+    .optional()
+    .describe(
+      "Array of glossary IDs to apply during translation (max 10). IDs must match format: gls_* (e.g., ['gls_xyz123'])."
+    ),
+  no_trace: z
+    .boolean()
+    .optional()
+    .describe(
+      "Privacy flag. If set to true, the request will not be traced or logged."
+    ),
+  style: z
+    .enum(["faithful", "fluid", "creative"])
+    .optional()
+    .describe(
+      "Controls how the translation balances accuracy against natural readability."
+    ),
+  voice_gender: z
+    .enum(["male", "female"])
+    .optional()
+    .describe(
+      "The gender of the voice for the translated audio output."
+    ),
+});
+
+export async function translateAudio(args: unknown, lara: Translator) {
+  const validatedArgs = translateAudioSchema.parse(args);
+  const {
+    file_path: filePath,
+    target,
+    source,
+    adapt_to,
+    glossaries,
+    no_trace,
+    style,
+    voice_gender,
+  } = validatedArgs;
+
+  // Validate file exists and is readable
+  try {
+    fs.accessSync(filePath, fs.constants.R_OK);
+  } catch {
+    throw new InvalidInputError(`File not found or not readable: ${filePath}`);
+  }
+
+  const filename = path.basename(filePath);
+
+  // Audit log for privacy-sensitive requests
+  if (no_trace) {
+    logger.info({
+      action: 'translate_audio',
+      privacySensitive: true,
+      timestamp: new Date().toISOString()
+    }, 'Privacy-sensitive audio translation requested (noTrace=true)');
+  }
+
+  // Build options object dynamically to avoid passing undefined values
+  const options: Record<string, unknown> = {};
+
+  if (typeof adapt_to !== "undefined") {
+    options.adaptTo = adapt_to;
+  }
+  if (typeof glossaries !== "undefined") {
+    options.glossaries = glossaries;
+  }
+  if (typeof no_trace !== "undefined") {
+    options.noTrace = no_trace;
+  }
+  if (typeof style !== "undefined") {
+    options.style = style;
+  }
+  if (typeof voice_gender !== "undefined") {
+    options.voiceGender = voice_gender;
+  }
+
+  return await lara.audio.upload(filePath, filename, source ?? null, target, options);
+}

--- a/src/mcp/tools/translate_audio.ts
+++ b/src/mcp/tools/translate_audio.ts
@@ -8,6 +8,14 @@ import { InvalidInputError } from "#exception";
 export const translateAudioSchema = z.object({
   file_path: z
     .string()
+    .refine(
+      (p) => path.isAbsolute(p),
+      "file_path must be an absolute path",
+    )
+    .refine(
+      (p) => !/(^|[\\/])\.\.([\\/]|$)/.test(p),
+      'file_path must not contain ".." path segments',
+    )
     .describe(
       "The absolute path to the audio file to translate."
     ),
@@ -44,7 +52,7 @@ export const translateAudioSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "Privacy flag. If set to true, the request will not be traced or logged."
+      "Privacy flag. If set to true, the request content will not be stored or traced by Lara."
     ),
   style: z
     .enum(["faithful", "fluid", "creative"])
@@ -73,14 +81,16 @@ export async function translateAudio(args: unknown, lara: Translator) {
     voice_gender,
   } = validatedArgs;
 
+  const normalizedFilePath = path.normalize(filePath);
+
   // Validate file exists and is readable
   try {
-    fs.accessSync(filePath, fs.constants.R_OK);
+    fs.accessSync(normalizedFilePath, fs.constants.R_OK);
   } catch {
-    throw new InvalidInputError(`File not found or not readable: ${filePath}`);
+    throw new InvalidInputError(`File not found or not readable: ${normalizedFilePath}`);
   }
 
-  const filename = path.basename(filePath);
+  const filename = path.basename(normalizedFilePath);
 
   // Audit log for privacy-sensitive requests
   if (no_trace) {
@@ -110,5 +120,5 @@ export async function translateAudio(args: unknown, lara: Translator) {
     options.voiceGender = voice_gender;
   }
 
-  return await lara.audio.upload(filePath, filename, source ?? null, target, options);
+  return await lara.audio.upload(normalizedFilePath, filename, source ?? null, target, options);
 }


### PR DESCRIPTION
## New
- translate_audio tool to upload audio files for async translation
- check_audio_translation_status tool to poll translation job status
- download_translated_audio tool to save translated audio to disk
- Step-based tool descriptions guiding LLMs through the 3-step workflow
- Tests for all three new tools (schema validation and handler behavior)

## Changed
- Registered audio tools in MCP tool handlers and ListTools
- Added audio namespace to test mock translator