### PR TITLE
feat: add image translation tools

### DIFF
--- a/src/__tests__/tools/translate_image.test.ts
+++ b/src/__tests__/tools/translate_image.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Readable } from 'stream';
+import { translateImage, translateImageSchema, streamToBuffer } from '../../mcp/tools/translate_image.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+setupTranslatorMock();
+
+const validBase64 = Buffer.from('fake image bytes').toString('base64');
+
+describe('translateImageSchema', () => {
+  it('should validate valid input with required fields', () => {
+    const input = { file_content: validBase64, target: 'it-IT' };
+    expect(() => translateImageSchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate valid input with all fields', () => {
+    const input = {
+      file_content: validBase64,
+      source: 'en-EN',
+      target: 'it-IT',
+      adapt_to: ['mem_123'],
+      glossaries: ['gls_abc123'],
+      no_trace: true,
+      style: 'fluid' as const,
+      text_removal: 'inpainting' as const,
+    };
+    expect(() => translateImageSchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing required fields', () => {
+    expect(() => translateImageSchema.parse({})).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      file_content: validBase64,
+      target: 'it-IT',
+      glossaries: ['bad'],
+    };
+    expect(() => translateImageSchema.parse(input)).toThrow();
+  });
+
+  it('should reject invalid text_removal value', () => {
+    const input = {
+      file_content: validBase64,
+      target: 'it-IT',
+      text_removal: 'magic',
+    };
+    expect(() => translateImageSchema.parse(input)).toThrow();
+  });
+
+  it('should reject more than 10 glossaries', () => {
+    const input = {
+      file_content: validBase64,
+      target: 'it-IT',
+      glossaries: Array.from({ length: 11 }, (_, i) => `gls_id${i}`),
+    };
+    expect(() => translateImageSchema.parse(input)).toThrow();
+  });
+});
+
+describe('streamToBuffer', () => {
+  it('should collect a readable stream into a buffer', async () => {
+    const data = 'hello stream';
+    const stream = Readable.from(Buffer.from(data));
+    const result = await streamToBuffer(stream);
+    expect(result.toString()).toBe(data);
+  });
+});
+
+describe('translateImage', () => {
+  let mockTranslator: MockTranslator;
+  const translatedBytes = 'translated image bytes';
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.images.translate = vi.fn().mockResolvedValue(
+      Readable.from(Buffer.from(translatedBytes))
+    );
+  });
+
+  it('should call lara.images.translate with correct parameters', async () => {
+    const args = {
+      file_content: validBase64,
+      source: 'en-EN',
+      target: 'it-IT',
+    };
+
+    const result = await translateImage(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.images.translate).toHaveBeenCalledOnce();
+    const [filePath, source, target] = mockTranslator.images.translate.mock.calls[0];
+    expect(typeof filePath).toBe('string');
+    expect(source).toBe('en-EN');
+    expect(target).toBe('it-IT');
+
+    // Verify base64 round-trip
+    const decoded = Buffer.from(result.content, 'base64').toString();
+    expect(decoded).toBe(translatedBytes);
+  });
+
+  it('should pass null source when omitted', async () => {
+    await translateImage({
+      file_content: validBase64,
+      target: 'it-IT',
+    }, mockTranslator as any as Translator);
+
+    const [, source] = mockTranslator.images.translate.mock.calls[0];
+    expect(source).toBeNull();
+  });
+
+  it('should build options with all optional fields', async () => {
+    await translateImage({
+      file_content: validBase64,
+      target: 'it-IT',
+      glossaries: ['gls_abc'],
+      style: 'creative',
+      adapt_to: ['mem_1'],
+      no_trace: true,
+      text_removal: 'inpainting',
+    }, mockTranslator as any as Translator);
+
+    const [, , , options] = mockTranslator.images.translate.mock.calls[0];
+    expect(options.glossaries).toEqual(['gls_abc']);
+    expect(options.style).toBe('creative');
+    expect(options.adaptTo).toEqual(['mem_1']);
+    expect(options.noTrace).toBe(true);
+    expect(options.textRemoval).toBe('inpainting');
+  });
+
+  it('should throw InvalidInputError for content exceeding 20MB', async () => {
+    const largeContent = Buffer.alloc(21 * 1024 * 1024).toString('base64');
+
+    await expect(translateImage({
+      file_content: largeContent,
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('Image too large');
+  });
+
+  it('should clean up temp files even on error', async () => {
+    mockTranslator.images.translate = vi.fn().mockRejectedValue(new Error('SDK error'));
+
+    await expect(translateImage({
+      file_content: validBase64,
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('SDK error');
+  });
+});

--- a/src/__tests__/tools/translate_image_text.test.ts
+++ b/src/__tests__/tools/translate_image_text.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { translateImageText, translateImageTextSchema } from '../../mcp/tools/translate_image_text.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+setupTranslatorMock();
+
+const validBase64 = Buffer.from('fake image bytes').toString('base64');
+
+describe('translateImageTextSchema', () => {
+  it('should validate valid input with required fields', () => {
+    const input = { file_content: validBase64, target: 'it-IT' };
+    expect(() => translateImageTextSchema.parse(input)).not.toThrow();
+  });
+
+  it('should validate valid input with all fields', () => {
+    const input = {
+      file_content: validBase64,
+      source: 'en-EN',
+      target: 'it-IT',
+      adapt_to: ['mem_123'],
+      glossaries: ['gls_abc123'],
+      no_trace: true,
+      style: 'faithful' as const,
+    };
+    expect(() => translateImageTextSchema.parse(input)).not.toThrow();
+  });
+
+  it('should reject missing required fields', () => {
+    expect(() => translateImageTextSchema.parse({})).toThrow();
+  });
+
+  it('should reject invalid glossary ID format', () => {
+    const input = {
+      file_content: validBase64,
+      target: 'it-IT',
+      glossaries: ['bad'],
+    };
+    expect(() => translateImageTextSchema.parse(input)).toThrow();
+  });
+});
+
+describe('translateImageText', () => {
+  let mockTranslator: MockTranslator;
+  const mockResult = {
+    paragraphs: [
+      { source: 'Hello', translation: 'Ciao' },
+      { source: 'World', translation: 'Mondo' },
+    ],
+  };
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+    mockTranslator.images.translateText = vi.fn().mockResolvedValue(mockResult);
+  });
+
+  it('should call lara.images.translateText with correct parameters', async () => {
+    const args = {
+      file_content: validBase64,
+      source: 'en-EN',
+      target: 'it-IT',
+    };
+
+    const result = await translateImageText(args, mockTranslator as any as Translator);
+
+    expect(mockTranslator.images.translateText).toHaveBeenCalledOnce();
+    const [filePath, source, target] = mockTranslator.images.translateText.mock.calls[0];
+    expect(typeof filePath).toBe('string');
+    expect(source).toBe('en-EN');
+    expect(target).toBe('it-IT');
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should pass null source when omitted', async () => {
+    await translateImageText({
+      file_content: validBase64,
+      target: 'it-IT',
+    }, mockTranslator as any as Translator);
+
+    const [, source] = mockTranslator.images.translateText.mock.calls[0];
+    expect(source).toBeNull();
+  });
+
+  it('should build options with all optional fields', async () => {
+    await translateImageText({
+      file_content: validBase64,
+      target: 'it-IT',
+      glossaries: ['gls_abc'],
+      style: 'creative',
+      adapt_to: ['mem_1'],
+      no_trace: true,
+    }, mockTranslator as any as Translator);
+
+    const [, , , options] = mockTranslator.images.translateText.mock.calls[0];
+    expect(options.glossaries).toEqual(['gls_abc']);
+    expect(options.style).toBe('creative');
+    expect(options.adaptTo).toEqual(['mem_1']);
+    expect(options.noTrace).toBe(true);
+  });
+
+  it('should throw InvalidInputError for content exceeding 20MB', async () => {
+    const largeContent = Buffer.alloc(21 * 1024 * 1024).toString('base64');
+
+    await expect(translateImageText({
+      file_content: largeContent,
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('Image too large');
+  });
+
+  it('should clean up temp files even on error', async () => {
+    mockTranslator.images.translateText = vi.fn().mockRejectedValue(new Error('SDK error'));
+
+    await expect(translateImageText({
+      file_content: validBase64,
+      target: 'it-IT',
+    }, mockTranslator as any as Translator)).rejects.toThrow('SDK error');
+  });
+});

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -57,6 +57,10 @@ export function createMockTranslator() {
       download: vi.fn(),
       translate: vi.fn(),
     },
+    images: {
+      translate: vi.fn(),
+      translateText: vi.fn(),
+    },
     client: {}
   };
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -37,6 +37,8 @@ import { translateHandler, translateSchema } from "./tools/translate.js";
 import { translateAudio, translateAudioSchema } from "./tools/translate_audio.js";
 import { checkAudioTranslationStatus, checkAudioTranslationStatusSchema } from "./tools/check_audio_translation_status.js";
 import { downloadTranslatedAudio, downloadTranslatedAudioSchema } from "./tools/download_translated_audio.js";
+import { translateImage, translateImageSchema } from "./tools/translate_image.js";
+import { translateImageText, translateImageTextSchema } from "./tools/translate_image_text.js";
 import { uploadDocument, uploadDocumentSchema } from "./tools/upload_document.js";
 import { checkDocumentStatus, checkDocumentStatusSchema } from "./tools/check_document_status.js";
 import { downloadDocument, downloadDocumentSchema } from "./tools/download_document.js";
@@ -77,6 +79,8 @@ const handlers: Record<string, Handler> = {
   check_document_status: checkDocumentStatus,
   download_document: downloadDocument,
   translate_document: translateDocument,
+  translate_image: translateImage,
+  translate_image_text: translateImageText,
 };
 
 const listers: Record<string, Lister> = {
@@ -312,6 +316,18 @@ async function ListTools() {
         description:
           "All-in-one document translation: uploads a document, waits for translation to complete, and returns the translated document as base64-encoded content. This is the simplest way to translate a document in a single call. Use this instead of the 3-step upload_document → check_document_status → download_document workflow unless you need to track progress or handle the steps separately.",
         inputSchema: z.toJSONSchema(translateDocumentSchema),
+      },
+      {
+        name: "translate_image",
+        description:
+          "All-in-one image translation: accepts a base64-encoded image, translates text within it, and returns the translated image as base64-encoded content in a single step. No separate upload, status polling, or download steps are needed. Source text in the image is replaced with the translation.",
+        inputSchema: z.toJSONSchema(translateImageSchema),
+      },
+      {
+        name: "translate_image_text",
+        description:
+          "All-in-one image text extraction and translation: accepts a base64-encoded image, extracts text from it, translates the text, and returns structured paragraphs with source text and translations in a single step. No separate upload, status polling, or download steps are needed. The original image is not modified.",
+        inputSchema: z.toJSONSchema(translateImageTextSchema),
       },
     ],
   };

--- a/src/mcp/tools/translate_image.ts
+++ b/src/mcp/tools/translate_image.ts
@@ -1,0 +1,85 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { Readable } from "stream";
+import { buildDocumentOptions, decodeAndValidateBase64 } from "./upload_document.js";
+
+export const imageBaseSchema = z.object({
+  file_content: z
+    .string()
+    .describe("Base64-encoded image file content."),
+  source: z
+    .string()
+    .optional()
+    .describe("Source language code (e.g., 'en-EN'). Auto-detected if omitted."),
+  target: z
+    .string()
+    .describe("Target language code (e.g., 'it-IT')."),
+  adapt_to: z
+    .array(z.string())
+    .optional()
+    .describe("A list of translation memory IDs for adapting the translation."),
+  glossaries: z
+    .array(
+      z.string()
+        .min(1)
+        .max(255)
+        .regex(/^gls_[a-zA-Z0-9_-]+$/, "Invalid glossary ID format")
+    )
+    .max(10)
+    .optional()
+    .describe("Array of glossary IDs to apply during translation (max 10). IDs must match format: gls_*."),
+  style: z
+    .enum(["faithful", "fluid", "creative"])
+    .optional()
+    .describe("Controls how the translation balances accuracy against natural readability."),
+  no_trace: z
+    .boolean()
+    .optional()
+    .describe("Privacy flag. If true, the request will not be traced or logged."),
+});
+
+export const translateImageSchema = imageBaseSchema.extend({
+  text_removal: z
+    .enum(["overlay", "inpainting"])
+    .optional()
+    .describe("Method for removing source text from the image. 'overlay' covers text with a solid background, 'inpainting' attempts to reconstruct the background."),
+});
+
+export async function streamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function translateImage(args: unknown, lara: Translator) {
+  const validatedArgs = translateImageSchema.parse(args);
+  const { file_content, source, target, text_removal } = validatedArgs;
+
+  const fileBuffer = decodeAndValidateBase64(file_content, "Image");
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-img-"));
+  const tempFilePath = path.join(tempDir, "upload");
+
+  try {
+    fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });
+    const options = buildDocumentOptions(validatedArgs);
+    if (typeof text_removal !== "undefined") {
+      options.textRemoval = text_removal;
+    }
+    const stream = await lara.images.translate(tempFilePath, source ?? null, target, options);
+    const resultBuffer = await streamToBuffer(stream as Readable);
+
+    return {
+      content: resultBuffer.toString("base64"),
+    };
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (_) { /* best-effort cleanup */ }
+  }
+}

--- a/src/mcp/tools/translate_image_text.ts
+++ b/src/mcp/tools/translate_image_text.ts
@@ -1,0 +1,28 @@
+import { Translator } from "@translated/lara";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { buildDocumentOptions, decodeAndValidateBase64 } from "./upload_document.js";
+import { imageBaseSchema } from "./translate_image.js";
+
+export const translateImageTextSchema = imageBaseSchema;
+
+export async function translateImageText(args: unknown, lara: Translator) {
+  const validatedArgs = translateImageTextSchema.parse(args);
+  const { file_content, source, target } = validatedArgs;
+
+  const fileBuffer = decodeAndValidateBase64(file_content, "Image");
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-img-"));
+  const tempFilePath = path.join(tempDir, "upload");
+
+  try {
+    fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });
+    const options = buildDocumentOptions(validatedArgs);
+    return await lara.images.translateText(tempFilePath, source ?? null, target, options);
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (_) { /* best-effort cleanup */ }
+  }
+}

--- a/src/mcp/tools/upload_document.ts
+++ b/src/mcp/tools/upload_document.ts
@@ -104,13 +104,13 @@ export function buildDocumentOptions(args: {
   return options;
 }
 
-export function decodeAndValidateBase64(file_content: string): Buffer {
+export function decodeAndValidateBase64(file_content: string, entityName = "Document"): Buffer {
   if (file_content.length > MAX_BASE64_LENGTH) {
-    throw new InvalidInputError("Document too large. Maximum allowed size is 20MB.");
+    throw new InvalidInputError(`${entityName} too large. Maximum allowed size is 20MB.`);
   }
   const buffer = Buffer.from(file_content, "base64");
   if (buffer.length > MAX_FILE_SIZE) {
-    throw new InvalidInputError("Document too large. Maximum allowed size is 20MB.");
+    throw new InvalidInputError(`${entityName} too large. Maximum allowed size is 20MB.`);
   }
   return buffer;
 }


### PR DESCRIPTION
## New
- translate_image tool to translate text within images and return translated image as base64
- translate_image_text tool to extract and translate text from images as structured paragraphs
- Shared image base schema with glossary, style, and privacy options
- streamToBuffer helper for collecting SDK stream responses

## Changed
- decodeAndValidateBase64 accepts optional entityName for contextual error messages
- Reuse buildDocumentOptions for image option building