### PR TITLE
feat: add language detection tool

### DIFF
--- a/src/__tests__/tools/detect_language.test.ts
+++ b/src/__tests__/tools/detect_language.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { detectLanguage, detectLanguageSchema } from '../../mcp/tools/detect_language.js';
+import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
+import { Translator } from '@translated/lara';
+
+// Setup mocks
+setupTranslatorMock();
+
+describe('detectLanguageSchema', () => {
+  it('should validate a single string', () => {
+    expect(() => detectLanguageSchema.parse({ text: 'Hello world' })).not.toThrow();
+  });
+
+  it('should validate an array of strings', () => {
+    expect(() => detectLanguageSchema.parse({ text: ['Hello', 'World'] })).not.toThrow();
+  });
+
+  it('should validate an empty array', () => {
+    expect(() => detectLanguageSchema.parse({ text: [] })).not.toThrow();
+  });
+
+  it('should reject an array exceeding 128 elements', () => {
+    const text = Array.from({ length: 129 }, (_, i) => `text ${i}`);
+    expect(() => detectLanguageSchema.parse({ text })).toThrow();
+  });
+
+  it('should validate with hint', () => {
+    expect(() => detectLanguageSchema.parse({ text: 'Bonjour', hint: 'fr-FR' })).not.toThrow();
+  });
+
+  it('should validate with passlist', () => {
+    expect(() => detectLanguageSchema.parse({ text: 'Bonjour', passlist: ['fr-FR', 'en-EN'] })).not.toThrow();
+  });
+
+  it('should reject invalid text type', () => {
+    expect(() => detectLanguageSchema.parse({ text: 123 })).toThrow();
+  });
+});
+
+describe('detectLanguage', () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = getMockTranslator();
+  });
+
+  it('should detect language for a single string', async () => {
+    const mockResult = {
+      language: 'en-EN',
+      contentType: 'text/plain',
+      predictions: [
+        { language: 'en-EN', confidence: 0.98 },
+        { language: 'de-DE', confidence: 0.01 },
+      ],
+    };
+
+    mockTranslator.detect.mockResolvedValue(mockResult);
+
+    const result = await detectLanguage({ text: 'Hello world' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.detect).toHaveBeenCalledWith('Hello world', undefined, undefined);
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should pass hint and passlist to the SDK', async () => {
+    const mockResult = {
+      language: 'fr-FR',
+      contentType: 'text/plain',
+      predictions: [{ language: 'fr-FR', confidence: 0.99 }],
+    };
+
+    mockTranslator.detect.mockResolvedValue(mockResult);
+
+    const result = await detectLanguage(
+      { text: 'Bonjour', hint: 'fr-FR', passlist: ['fr-FR', 'en-EN'] },
+      mockTranslator as any as Translator,
+    );
+
+    expect(mockTranslator.detect).toHaveBeenCalledWith('Bonjour', 'fr-FR', ['fr-FR', 'en-EN']);
+    expect(result).toEqual(mockResult);
+  });
+
+  it('should only pass defined optional params', async () => {
+    const mockResult = {
+      language: 'it-IT',
+      contentType: 'text/plain',
+      predictions: [{ language: 'it-IT', confidence: 0.95 }],
+    };
+
+    mockTranslator.detect.mockResolvedValue(mockResult);
+
+    await detectLanguage({ text: 'Ciao mondo' }, mockTranslator as any as Translator);
+
+    expect(mockTranslator.detect).toHaveBeenCalledWith('Ciao mondo', undefined, undefined);
+  });
+
+  it('should detect language for an array of strings', async () => {
+    const mockResult = {
+      language: 'es-ES',
+      contentType: 'text/plain',
+      predictions: [{ language: 'es-ES', confidence: 0.97 }],
+    };
+
+    mockTranslator.detect.mockResolvedValue(mockResult);
+
+    const result = await detectLanguage(
+      { text: ['Hola', 'Mundo'] },
+      mockTranslator as any as Translator,
+    );
+
+    expect(mockTranslator.detect).toHaveBeenCalledWith(['Hola', 'Mundo'], undefined, undefined);
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -11,6 +11,7 @@ export type MockTranslator = ReturnType<typeof createMockTranslator>;
  */
 export function createMockTranslator() {
   return {
+    detect: vi.fn(),
     translate: vi.fn(),
     getLanguages: vi.fn(),
     createMemory: vi.fn(),

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -33,6 +33,7 @@ import { exportGlossary, exportGlossarySchema } from "./tools/export_glossary.js
 import { getGlossaryCounts, getGlossaryCountsSchema } from "./tools/get_glossary_counts.js";
 import { addGlossaryEntry, addGlossaryEntrySchema } from "./tools/add_glossary_entry.js";
 import { deleteGlossaryEntry, deleteGlossaryEntrySchema } from "./tools/delete_glossary_entry.js";
+import { detectLanguage, detectLanguageSchema } from "./tools/detect_language.js";
 import { translateHandler, translateSchema } from "./tools/translate.js";
 import { translateAudio, translateAudioSchema } from "./tools/translate_audio.js";
 import { checkAudioTranslationStatus, checkAudioTranslationStatusSchema } from "./tools/check_audio_translation_status.js";
@@ -54,6 +55,7 @@ type Handler = (args: any, lara: Translator) => Promise<any>;
 type Lister = (lara: Translator) => Promise<any>;
 
 const handlers: Record<string, Handler> = {
+  detect_language: detectLanguage,
   translate: translateHandler,
   create_memory: createMemory,
   delete_memory: deleteMemory,
@@ -149,6 +151,12 @@ async function CallTool(
 async function ListTools() {
   return {
     tools: [
+      {
+        name: "detect_language",
+        description:
+          "Detects the language of the provided text. Returns the detected language, content type, and a list of predictions with confidence scores. Accepts a single string or an array of strings (up to 128 elements).",
+        inputSchema: z.toJSONSchema(detectLanguageSchema),
+      },
       {
         name: "translate",
         description:

--- a/src/mcp/tools/detect_language.ts
+++ b/src/mcp/tools/detect_language.ts
@@ -1,0 +1,28 @@
+import { Translator } from "@translated/lara";
+import { z } from "zod/v4";
+
+export const detectLanguageSchema = z.object({
+  text: z
+    .union([z.string(), z.array(z.string()).max(128)])
+    .describe(
+      "The text to detect the language of. Can be a single string or an array of strings (up to 128 elements)."
+    ),
+  hint: z
+    .string()
+    .optional()
+    .describe(
+      "Optional language code hint to guide detection (e.g., 'en-EN')."
+    ),
+  passlist: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Optional list of language codes to restrict detection results to."
+    ),
+});
+
+export async function detectLanguage(args: unknown, lara: Translator) {
+  const { text, hint, passlist } = detectLanguageSchema.parse(args);
+
+  return lara.detect(text, hint, passlist);
+}


### PR DESCRIPTION
## New
- detect_language tool to identify the language of input text
- Supports single string or array of strings (up to 128 elements)
- Optional hint and passlist parameters to guide detection
- Schema validation and handler tests for all input variants