### PR TITLE
fix: use base64 for audio translation tools

### DIFF
--- a/src/__tests__/tools/download_translated_audio.test.ts
+++ b/src/__tests__/tools/download_translated_audio.test.ts
@@ -2,133 +2,60 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { downloadTranslatedAudio, downloadTranslatedAudioSchema } from '../../mcp/tools/download_translated_audio.js';
 import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
 import { Translator } from '@translated/lara';
-import * as fs from 'fs';
 import { PassThrough } from 'stream';
 
 // Setup mocks
 setupTranslatorMock();
 
-vi.mock('fs', async () => {
-  const actual = await vi.importActual<typeof fs>('fs');
-  return {
-    ...actual,
-    accessSync: vi.fn(),
-    createWriteStream: vi.fn(),
-    renameSync: vi.fn(),
-    unlinkSync: vi.fn(),
-  };
-});
-
-vi.mock('stream/promises', () => ({
-  pipeline: vi.fn(),
-}));
-
 describe('downloadTranslatedAudioSchema', () => {
   it('should validate valid input', () => {
     expect(() => downloadTranslatedAudioSchema.parse({
       id: 'audio_123',
-      output_path: '/tmp/translated.mp3',
     })).not.toThrow();
   });
 
   it('should reject missing id', () => {
-    expect(() => downloadTranslatedAudioSchema.parse({
-      output_path: '/tmp/translated.mp3',
-    })).toThrow();
-  });
-
-  it('should reject missing output_path', () => {
-    expect(() => downloadTranslatedAudioSchema.parse({
-      id: 'audio_123',
-    })).toThrow();
-  });
-
-  it('should reject relative output_path', () => {
-    expect(() => downloadTranslatedAudioSchema.parse({
-      id: 'audio_123',
-      output_path: 'relative/translated.mp3',
-    })).toThrow();
-  });
-
-  it('should reject output_path with ".." segments', () => {
-    expect(() => downloadTranslatedAudioSchema.parse({
-      id: 'audio_123',
-      output_path: '/tmp/../etc/translated.mp3',
-    })).toThrow();
+    expect(() => downloadTranslatedAudioSchema.parse({})).toThrow();
   });
 });
 
 describe('downloadTranslatedAudio', () => {
   let mockTranslator: MockTranslator;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
     mockTranslator = getMockTranslator();
-    vi.mocked(fs.accessSync).mockImplementation(() => undefined);
-    vi.mocked(fs.renameSync).mockImplementation(() => undefined);
-
-    const { pipeline } = await import('stream/promises');
-    vi.mocked(pipeline).mockResolvedValue(undefined);
   });
 
-  it('should download and save audio file via temp file', async () => {
+  it('should download audio and return base64 content', async () => {
+    const audioData = Buffer.from('translated audio data');
     const mockStream = new PassThrough();
+    mockStream.end(audioData);
     mockTranslator.audio.download.mockResolvedValue(mockStream);
 
-    const mockWriteStream = new PassThrough();
-    vi.mocked(fs.createWriteStream).mockReturnValue(mockWriteStream as any);
-
     const result = await downloadTranslatedAudio(
-      { id: 'audio_123', output_path: '/tmp/translated.mp3' },
+      { id: 'audio_123' },
       mockTranslator as any as Translator
     );
 
     expect(mockTranslator.audio.download).toHaveBeenCalledWith('audio_123');
-    // Should write to a temp file, then rename
-    expect(fs.createWriteStream).toHaveBeenCalledWith(expect.stringMatching(/^\/tmp\/\.lara-download-[a-f0-9]+\.tmp$/));
-    expect(fs.renameSync).toHaveBeenCalledWith(
-      expect.stringMatching(/^\/tmp\/\.lara-download-[a-f0-9]+\.tmp$/),
-      '/tmp/translated.mp3'
-    );
     expect(result).toEqual({
-      output_path: '/tmp/translated.mp3',
-      message: 'Translated audio saved successfully.',
+      content: audioData.toString('base64'),
     });
   });
 
-  it('should throw on unwritable output directory', async () => {
-    vi.mocked(fs.accessSync).mockImplementation(() => {
-      throw new Error('EACCES');
-    });
-
-    await expect(
-      downloadTranslatedAudio(
-        { id: 'audio_123', output_path: '/readonly/translated.mp3' },
-        mockTranslator as any as Translator
-      )
-    ).rejects.toThrow('Output directory not found or not writable');
-  });
-
-  it('should clean up temp file on pipeline error without deleting target', async () => {
+  it('should handle empty stream', async () => {
     const mockStream = new PassThrough();
+    mockStream.end();
     mockTranslator.audio.download.mockResolvedValue(mockStream);
 
-    const mockWriteStream = new PassThrough();
-    vi.mocked(fs.createWriteStream).mockReturnValue(mockWriteStream as any);
+    const result = await downloadTranslatedAudio(
+      { id: 'audio_456' },
+      mockTranslator as any as Translator
+    );
 
-    const { pipeline } = await import('stream/promises');
-    vi.mocked(pipeline).mockRejectedValue(new Error('Stream error'));
-
-    await expect(
-      downloadTranslatedAudio(
-        { id: 'audio_123', output_path: '/tmp/translated.mp3' },
-        mockTranslator as any as Translator
-      )
-    ).rejects.toThrow('Stream error');
-
-    // Should clean up the temp file, not the target path
-    expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringMatching(/^\/tmp\/\.lara-download-[a-f0-9]+\.tmp$/));
-    expect(fs.unlinkSync).not.toHaveBeenCalledWith('/tmp/translated.mp3');
-    expect(fs.renameSync).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      content: '',
+    });
   });
 });

--- a/src/__tests__/tools/translate_audio.test.ts
+++ b/src/__tests__/tools/translate_audio.test.ts
@@ -11,14 +11,19 @@ vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof fs>('fs');
   return {
     ...actual,
-    accessSync: vi.fn(),
+    mkdtempSync: vi.fn(() => '/tmp/lara-audio-abc123'),
+    writeFileSync: vi.fn(),
+    rmSync: vi.fn(),
   };
 });
+
+const VALID_BASE64 = Buffer.from('fake audio content').toString('base64');
 
 describe('translateAudioSchema', () => {
   it('should validate valid input with all fields', () => {
     const input = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       source: 'en-EN',
       adapt_to: ['mem_123'],
@@ -33,26 +38,33 @@ describe('translateAudioSchema', () => {
 
   it('should validate valid input with only required fields', () => {
     const input = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
     };
 
     expect(() => translateAudioSchema.parse(input)).not.toThrow();
   });
 
-  it('should reject missing file_path', () => {
-    const input = { target: 'it-IT' };
+  it('should reject missing file_content', () => {
+    const input = { filename: 'audio.mp3', target: 'it-IT' };
+    expect(() => translateAudioSchema.parse(input)).toThrow();
+  });
+
+  it('should reject missing filename', () => {
+    const input = { file_content: VALID_BASE64, target: 'it-IT' };
     expect(() => translateAudioSchema.parse(input)).toThrow();
   });
 
   it('should reject missing target', () => {
-    const input = { file_path: '/tmp/audio.mp3' };
+    const input = { file_content: VALID_BASE64, filename: 'audio.mp3' };
     expect(() => translateAudioSchema.parse(input)).toThrow();
   });
 
   it('should reject invalid glossary ID format', () => {
     const input = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       glossaries: ['invalid_id'],
     };
@@ -61,7 +73,8 @@ describe('translateAudioSchema', () => {
 
   it('should reject more than 10 glossaries', () => {
     const input = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       glossaries: Array.from({ length: 11 }, (_, i) => `gls_id${i}`),
     };
@@ -70,7 +83,8 @@ describe('translateAudioSchema', () => {
 
   it('should reject invalid style value', () => {
     const input = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       style: 'invalid',
     };
@@ -79,24 +93,18 @@ describe('translateAudioSchema', () => {
 
   it('should reject invalid voice_gender value', () => {
     const input = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       voice_gender: 'other',
     };
     expect(() => translateAudioSchema.parse(input)).toThrow();
   });
 
-  it('should reject relative file_path', () => {
+  it('should reject empty filename', () => {
     const input = {
-      file_path: 'relative/audio.mp3',
-      target: 'it-IT',
-    };
-    expect(() => translateAudioSchema.parse(input)).toThrow();
-  });
-
-  it('should reject file_path with ".." segments', () => {
-    const input = {
-      file_path: '/tmp/../etc/passwd',
+      file_content: VALID_BASE64,
+      filename: '',
       target: 'it-IT',
     };
     expect(() => translateAudioSchema.parse(input)).toThrow();
@@ -108,7 +116,6 @@ describe('translateAudio', () => {
 
   beforeEach(() => {
     mockTranslator = getMockTranslator();
-    vi.mocked(fs.accessSync).mockImplementation(() => undefined);
   });
 
   it('should call lara.audio.upload with correct args', async () => {
@@ -121,7 +128,8 @@ describe('translateAudio', () => {
     mockTranslator.audio.upload.mockResolvedValue(mockResult);
 
     const args = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       source: 'en-EN',
     };
@@ -129,7 +137,7 @@ describe('translateAudio', () => {
     const result = await translateAudio(args, mockTranslator as any as Translator);
 
     expect(mockTranslator.audio.upload).toHaveBeenCalledWith(
-      '/tmp/audio.mp3',
+      '/tmp/lara-audio-abc123/upload',
       'audio.mp3',
       'en-EN',
       'it-IT',
@@ -142,10 +150,10 @@ describe('translateAudio', () => {
     const mockResult = { id: 'audio_123', status: 'initialized', target: 'it-IT', filename: 'audio.mp3' };
     mockTranslator.audio.upload.mockResolvedValue(mockResult);
 
-    await translateAudio({ file_path: '/tmp/audio.mp3', target: 'it-IT' }, mockTranslator as any as Translator);
+    await translateAudio({ file_content: VALID_BASE64, filename: 'audio.mp3', target: 'it-IT' }, mockTranslator as any as Translator);
 
     expect(mockTranslator.audio.upload).toHaveBeenCalledWith(
-      '/tmp/audio.mp3',
+      '/tmp/lara-audio-abc123/upload',
       'audio.mp3',
       null,
       'it-IT',
@@ -157,7 +165,8 @@ describe('translateAudio', () => {
     mockTranslator.audio.upload.mockResolvedValue({ id: 'audio_123' });
 
     const args = {
-      file_path: '/tmp/audio.mp3',
+      file_content: VALID_BASE64,
+      filename: 'audio.mp3',
       target: 'it-IT',
       glossaries: ['gls_abc'],
       style: 'fluid',
@@ -169,7 +178,7 @@ describe('translateAudio', () => {
     await translateAudio(args, mockTranslator as any as Translator);
 
     expect(mockTranslator.audio.upload).toHaveBeenCalledWith(
-      '/tmp/audio.mp3',
+      '/tmp/lara-audio-abc123/upload',
       'audio.mp3',
       null,
       'it-IT',
@@ -183,13 +192,22 @@ describe('translateAudio', () => {
     );
   });
 
-  it('should throw on unreadable file', async () => {
-    vi.mocked(fs.accessSync).mockImplementation(() => {
-      throw new Error('ENOENT');
-    });
+  it('should write decoded content to temp file and clean up', async () => {
+    mockTranslator.audio.upload.mockResolvedValue({ id: 'audio_123' });
 
-    await expect(
-      translateAudio({ file_path: '/nonexistent/file.mp3', target: 'it-IT' }, mockTranslator as any as Translator)
-    ).rejects.toThrow('File not found or not readable');
+    await translateAudio(
+      { file_content: VALID_BASE64, filename: 'audio.mp3', target: 'it-IT' },
+      mockTranslator as any as Translator
+    );
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/tmp/lara-audio-abc123/upload',
+      expect.any(Buffer),
+      { mode: 0o600 }
+    );
+    expect(fs.rmSync).toHaveBeenCalledWith(
+      '/tmp/lara-audio-abc123',
+      { recursive: true, force: true }
+    );
   });
 });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -286,7 +286,7 @@ async function ListTools() {
       {
         name: "translate_audio",
         description:
-          "Step 1 of 3 for audio translation. Uploads an audio file and starts an asynchronous translation job. The job may take minutes to complete. After calling this tool, use check_audio_translation_status to poll until status is 'translated', then use download_translated_audio to save the result.",
+          "Step 1 of 3 for audio translation. Accepts base64-encoded audio and starts an asynchronous translation job. The job may take minutes to complete. After calling this tool, use check_audio_translation_status to poll until status is 'translated', then use download_translated_audio to get the result.",
         inputSchema: z.toJSONSchema(translateAudioSchema),
       },
       {
@@ -298,7 +298,7 @@ async function ListTools() {
       {
         name: "download_translated_audio",
         description:
-          "Step 3 of 3 for audio translation. Downloads the translated audio file to disk. Only call this after check_audio_translation_status returns status 'translated'. Requires the job id from translate_audio and an output_path where the file will be saved.",
+          "Step 3 of 3 for audio translation. Downloads the translated audio and returns it as base64-encoded content. Only call this after check_audio_translation_status returns status 'translated'. Requires the job id from translate_audio.",
         inputSchema: z.toJSONSchema(downloadTranslatedAudioSchema),
       },
       {

--- a/src/mcp/tools/download_translated_audio.ts
+++ b/src/mcp/tools/download_translated_audio.ts
@@ -1,58 +1,20 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
-import * as crypto from "crypto";
-import * as fs from "fs";
-import * as path from "path";
-import { pipeline } from "stream/promises";
-import { InvalidInputError } from "#exception";
+import { Readable } from "stream";
+import { streamToBuffer } from "./translate_image.js";
 
 export const downloadTranslatedAudioSchema = z.object({
   id: z.string().describe("The ID of the audio translation job returned by translate_audio."),
-  output_path: z
-    .string()
-    .refine(
-      (p) => path.isAbsolute(p),
-      "output_path must be an absolute path",
-    )
-    .refine(
-      (p) => !/(^|[\\/])\.\.([\\/]|$)/.test(p),
-      'output_path must not contain ".." path segments',
-    )
-    .describe(
-      "The absolute path where the translated audio file will be saved."
-    ),
 });
 
 export async function downloadTranslatedAudio(args: unknown, lara: Translator) {
   const validatedArgs = downloadTranslatedAudioSchema.parse(args);
-  const { id, output_path } = validatedArgs;
-
-  const normalizedOutputPath = path.normalize(output_path);
-
-  // Validate output directory exists and is writable
-  const outputDir = path.dirname(normalizedOutputPath);
-  try {
-    fs.accessSync(outputDir, fs.constants.W_OK);
-  } catch {
-    throw new InvalidInputError(`Output directory not found or not writable: ${outputDir}`);
-  }
+  const { id } = validatedArgs;
 
   const readable = await lara.audio.download(id);
+  const resultBuffer = await streamToBuffer(readable as Readable);
 
-  // Write to a temp file first, then atomically rename to avoid
-  // destroying a pre-existing file on transient download errors.
-  const tempPath = path.join(outputDir, `.lara-download-${crypto.randomBytes(8).toString('hex')}.tmp`);
-
-  try {
-    await pipeline(readable, fs.createWriteStream(tempPath));
-    fs.renameSync(tempPath, normalizedOutputPath);
-  } catch (error) {
-    // Best-effort cleanup of temp file only
-    try {
-      fs.unlinkSync(tempPath);
-    } catch { /* ignore cleanup errors */ }
-    throw error;
-  }
-
-  return { output_path: normalizedOutputPath, message: "Translated audio saved successfully." };
+  return {
+    content: resultBuffer.toString("base64"),
+  };
 }

--- a/src/mcp/tools/translate_audio.ts
+++ b/src/mcp/tools/translate_audio.ts
@@ -1,23 +1,22 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import { logger } from "#logger";
-import { InvalidInputError } from "#exception";
+import { buildDocumentOptions, decodeAndValidateBase64 } from "./upload_document.js";
 
 export const translateAudioSchema = z.object({
-  file_path: z
+  file_content: z
     .string()
-    .refine(
-      (p) => path.isAbsolute(p),
-      "file_path must be an absolute path",
-    )
-    .refine(
-      (p) => !/(^|[\\/])\.\.([\\/]|$)/.test(p),
-      'file_path must not contain ".." path segments',
-    )
     .describe(
-      "The absolute path to the audio file to translate."
+      "Base64-encoded audio file content."
+    ),
+  filename: z
+    .string()
+    .min(1)
+    .describe(
+      "Original filename with extension (e.g., 'recording.mp3'). Used for format detection."
     ),
   target: z
     .string()
@@ -70,30 +69,12 @@ export const translateAudioSchema = z.object({
 
 export async function translateAudio(args: unknown, lara: Translator) {
   const validatedArgs = translateAudioSchema.parse(args);
-  const {
-    file_path: filePath,
-    target,
-    source,
-    adapt_to,
-    glossaries,
-    no_trace,
-    style,
-    voice_gender,
-  } = validatedArgs;
+  const { file_content, filename, target, source, voice_gender } = validatedArgs;
 
-  const normalizedFilePath = path.normalize(filePath);
-
-  // Validate file exists and is readable
-  try {
-    fs.accessSync(normalizedFilePath, fs.constants.R_OK);
-  } catch {
-    throw new InvalidInputError(`File not found or not readable: ${normalizedFilePath}`);
-  }
-
-  const filename = path.basename(normalizedFilePath);
+  const fileBuffer = decodeAndValidateBase64(file_content, "Audio file");
 
   // Audit log for privacy-sensitive requests
-  if (no_trace) {
+  if (validatedArgs.no_trace) {
     logger.info({
       action: 'translate_audio',
       privacySensitive: true,
@@ -101,24 +82,20 @@ export async function translateAudio(args: unknown, lara: Translator) {
     }, 'Privacy-sensitive audio translation requested (noTrace=true)');
   }
 
-  // Build options object dynamically to avoid passing undefined values
-  const options: Record<string, unknown> = {};
-
-  if (typeof adapt_to !== "undefined") {
-    options.adaptTo = adapt_to;
-  }
-  if (typeof glossaries !== "undefined") {
-    options.glossaries = glossaries;
-  }
-  if (typeof no_trace !== "undefined") {
-    options.noTrace = no_trace;
-  }
-  if (typeof style !== "undefined") {
-    options.style = style;
-  }
+  const options = buildDocumentOptions(validatedArgs);
   if (typeof voice_gender !== "undefined") {
     options.voiceGender = voice_gender;
   }
 
-  return await lara.audio.upload(normalizedFilePath, filename, source ?? null, target, options);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-audio-"));
+  const tempFilePath = path.join(tempDir, "upload");
+
+  try {
+    fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });
+    return await lara.audio.upload(tempFilePath, filename, source ?? null, target, options);
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (_) { /* best-effort cleanup */ }
+  }
 }


### PR DESCRIPTION
## Changed
- translate_audio accepts base64-encoded content instead of local file path
- download_translated_audio returns base64 content instead of writing to disk
- Tool descriptions updated to reflect base64-based interface
- translate_audio reuses buildDocumentOptions for option mapping