### PR TITLE
fix: detect image type and increase body limit

### DIFF
--- a/src/__tests__/tools/translate_image.test.ts
+++ b/src/__tests__/tools/translate_image.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Readable } from 'stream';
-import { translateImage, translateImageSchema, streamToBuffer } from '../../mcp/tools/translate_image.js';
+import { translateImage, translateImageSchema, streamToBuffer, detectImageExtension } from '../../mcp/tools/translate_image.js';
 import { getMockTranslator, setupTranslatorMock, type MockTranslator } from '../utils/mocks.js';
 import { Translator } from '@translated/lara';
 
@@ -60,6 +60,38 @@ describe('translateImageSchema', () => {
   });
 });
 
+describe('detectImageExtension', () => {
+  it('should detect PNG from magic bytes', () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(detectImageExtension(buf)).toBe('.png');
+  });
+
+  it('should detect JPEG from magic bytes', () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    expect(detectImageExtension(buf)).toBe('.jpg');
+  });
+
+  it('should detect GIF from magic bytes', () => {
+    const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    expect(detectImageExtension(buf)).toBe('.gif');
+  });
+
+  it('should detect WebP from magic bytes', () => {
+    const buf = Buffer.from([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]);
+    expect(detectImageExtension(buf)).toBe('.webp');
+  });
+
+  it('should detect BMP from magic bytes', () => {
+    const buf = Buffer.from([0x42, 0x4d, 0x00, 0x00]);
+    expect(detectImageExtension(buf)).toBe('.bmp');
+  });
+
+  it('should default to .png for unknown formats', () => {
+    const buf = Buffer.from([0x00, 0x00, 0x00, 0x00]);
+    expect(detectImageExtension(buf)).toBe('.png');
+  });
+});
+
 describe('streamToBuffer', () => {
   it('should collect a readable stream into a buffer', async () => {
     const data = 'hello stream';
@@ -78,6 +110,30 @@ describe('translateImage', () => {
     mockTranslator.images.translate = vi.fn().mockResolvedValue(
       Readable.from(Buffer.from(translatedBytes))
     );
+  });
+
+  it('should create temp file with correct extension for PNG', async () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+    const args = {
+      file_content: pngBytes.toString('base64'),
+      target: 'it-IT',
+    };
+
+    await translateImage(args, mockTranslator as any as Translator);
+    const [filePath] = mockTranslator.images.translate.mock.calls[0];
+    expect(filePath).toMatch(/\.png$/);
+  });
+
+  it('should create temp file with correct extension for JPEG', async () => {
+    const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const args = {
+      file_content: jpegBytes.toString('base64'),
+      target: 'it-IT',
+    };
+
+    await translateImage(args, mockTranslator as any as Translator);
+    const [filePath] = mockTranslator.images.translate.mock.calls[0];
+    expect(filePath).toMatch(/\.jpg$/);
   });
 
   it('should call lara.images.translate with correct parameters', async () => {

--- a/src/__tests__/tools/translate_image.test.ts
+++ b/src/__tests__/tools/translate_image.test.ts
@@ -6,7 +6,7 @@ import { Translator } from '@translated/lara';
 
 setupTranslatorMock();
 
-const validBase64 = Buffer.from('fake image bytes').toString('base64');
+const validBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]).toString('base64');
 
 describe('translateImageSchema', () => {
   it('should validate valid input with required fields', () => {
@@ -86,9 +86,9 @@ describe('detectImageExtension', () => {
     expect(detectImageExtension(buf)).toBe('.bmp');
   });
 
-  it('should default to .png for unknown formats', () => {
+  it('should throw for unsupported formats', () => {
     const buf = Buffer.from([0x00, 0x00, 0x00, 0x00]);
-    expect(detectImageExtension(buf)).toBe('.png');
+    expect(() => detectImageExtension(buf)).toThrow('Unsupported image format');
   });
 });
 

--- a/src/__tests__/tools/translate_image_text.test.ts
+++ b/src/__tests__/tools/translate_image_text.test.ts
@@ -5,7 +5,7 @@ import { Translator } from '@translated/lara';
 
 setupTranslatorMock();
 
-const validBase64 = Buffer.from('fake image bytes').toString('base64');
+const validBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]).toString('base64');
 
 describe('translateImageTextSchema', () => {
   it('should validate valid input with required fields', () => {

--- a/src/__tests__/tools/translate_image_text.test.ts
+++ b/src/__tests__/tools/translate_image_text.test.ts
@@ -54,6 +54,30 @@ describe('translateImageText', () => {
     mockTranslator.images.translateText = vi.fn().mockResolvedValue(mockResult);
   });
 
+  it('should create temp file with correct extension for PNG', async () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+    const args = {
+      file_content: pngBytes.toString('base64'),
+      target: 'it-IT',
+    };
+
+    await translateImageText(args, mockTranslator as any as Translator);
+    const [filePath] = mockTranslator.images.translateText.mock.calls[0];
+    expect(filePath).toMatch(/\.png$/);
+  });
+
+  it('should create temp file with correct extension for JPEG', async () => {
+    const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const args = {
+      file_content: jpegBytes.toString('base64'),
+      target: 'it-IT',
+    };
+
+    await translateImageText(args, mockTranslator as any as Translator);
+    const [filePath] = mockTranslator.images.translateText.mock.calls[0];
+    expect(filePath).toMatch(/\.jpg$/);
+  });
+
   it('should call lara.images.translateText with correct parameters', async () => {
     const args = {
       file_content: validBase64,

--- a/src/mcp/tools/translate_image.ts
+++ b/src/mcp/tools/translate_image.ts
@@ -48,6 +48,26 @@ export const translateImageSchema = imageBaseSchema.extend({
     .describe("Method for removing source text from the image. 'overlay' covers text with a solid background, 'inpainting' attempts to reconstruct the background."),
 });
 
+export function detectImageExtension(buffer: Buffer): string {
+  if (buffer.length >= 4 && buffer[0] === 0x89 && buffer[1] === 0x50 && buffer[2] === 0x4e && buffer[3] === 0x47) {
+    return ".png";
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return ".jpg";
+  }
+  if (buffer.length >= 4 && buffer[0] === 0x47 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x38) {
+    return ".gif";
+  }
+  if (buffer.length >= 12 && buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
+      buffer[8] === 0x57 && buffer[9] === 0x45 && buffer[10] === 0x42 && buffer[11] === 0x50) {
+    return ".webp";
+  }
+  if (buffer.length >= 2 && buffer[0] === 0x42 && buffer[1] === 0x4d) {
+    return ".bmp";
+  }
+  return ".png";
+}
+
 export async function streamToBuffer(stream: Readable): Promise<Buffer> {
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {
@@ -62,8 +82,9 @@ export async function translateImage(args: unknown, lara: Translator) {
 
   const fileBuffer = decodeAndValidateBase64(file_content, "Image");
 
+  const ext = detectImageExtension(fileBuffer);
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-img-"));
-  const tempFilePath = path.join(tempDir, "upload");
+  const tempFilePath = path.join(tempDir, `upload${ext}`);
 
   try {
     fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });

--- a/src/mcp/tools/translate_image.ts
+++ b/src/mcp/tools/translate_image.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { Readable } from "stream";
+import { InvalidInputError } from "#exception";
 import { buildDocumentOptions, decodeAndValidateBase64 } from "./upload_document.js";
 
 export const imageBaseSchema = z.object({
@@ -65,7 +66,7 @@ export function detectImageExtension(buffer: Buffer): string {
   if (buffer.length >= 2 && buffer[0] === 0x42 && buffer[1] === 0x4d) {
     return ".bmp";
   }
-  return ".png";
+  throw new InvalidInputError("Unsupported image format. Supported formats: PNG, JPEG, GIF, WebP, BMP.");
 }
 
 export async function streamToBuffer(stream: Readable): Promise<Buffer> {

--- a/src/mcp/tools/translate_image_text.ts
+++ b/src/mcp/tools/translate_image_text.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { buildDocumentOptions, decodeAndValidateBase64 } from "./upload_document.js";
-import { imageBaseSchema } from "./translate_image.js";
+import { detectImageExtension, imageBaseSchema } from "./translate_image.js";
 
 export const translateImageTextSchema = imageBaseSchema;
 
@@ -13,8 +13,9 @@ export async function translateImageText(args: unknown, lara: Translator) {
 
   const fileBuffer = decodeAndValidateBase64(file_content, "Image");
 
+  const ext = detectImageExtension(fileBuffer);
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lara-img-"));
-  const tempFilePath = path.join(tempDir, "upload");
+  const tempFilePath = path.join(tempDir, `upload${ext}`);
 
   try {
     fs.writeFileSync(tempFilePath, fileBuffer, { mode: 0o600 });

--- a/src/rest/server.ts
+++ b/src/rest/server.ts
@@ -26,7 +26,7 @@ export class RestServer {
     this.express = express();
 
     // -- Json parser
-    this.express.use(express.json());
+    this.express.use(express.json({ limit: "30mb" }));
 
     // -- Security
     this.express.use(cors);

--- a/src/rest/server.ts
+++ b/src/rest/server.ts
@@ -25,7 +25,7 @@ export class RestServer {
 
     this.express = express();
 
-    // -- Json parser
+    // -- Json parser (30MB accommodates 20MB file limit after base64 encoding ~27MB + JSON overhead)
     this.express.use(express.json({ limit: "30mb" }));
 
     // -- Security


### PR DESCRIPTION
## Changed
- Temp files now include correct extension (.png, .jpg, etc.) based on magic bytes so the SDK infers the right MIME type
- Express JSON body limit increased from 100KB to 30MB to support base64-encoded images

## New
- detectImageExtension helper to identify image format from buffer magic bytes (PNG, JPEG, GIF, WebP, BMP)
- Tests for magic byte detection and temp file extension in both image tools