### PR TITLE
fix: improve instructions parameter descriptions and validation

### DIFF
--- a/src/__tests__/tools/translate.test.ts
+++ b/src/__tests__/tools/translate.test.ts
@@ -122,6 +122,57 @@ describe('translateSchema', () => {
     })).toThrow();
   });
 
+  it('should accept instructions with fewer than 20 words each', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      instructions: ['Translate formally', 'Use a creative and concise tone']
+    })).not.toThrow();
+  });
+
+  it('should accept an instruction with exactly 20 words', () => {
+    const twentyWords = Array(20).fill('word').join(' ');
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      instructions: [twentyWords]
+    })).not.toThrow();
+  });
+
+  it('should reject an instruction with more than 20 words', () => {
+    const twentyOneWords = Array(21).fill('word').join(' ');
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      instructions: [twentyOneWords]
+    })).toThrow(/no more than 20 words/);
+  });
+
+  it('should reject when any instruction exceeds the word limit', () => {
+    const longInstruction = Array(25).fill('word').join(' ');
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      instructions: ['Translate formally', longInstruction]
+    })).toThrow(/no more than 20 words/);
+  });
+
+  it('should accept an empty instructions array', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      instructions: []
+    })).not.toThrow();
+  });
+
+  it('should handle instructions with extra whitespace correctly', () => {
+    expect(() => translateSchema.parse({
+      text: [{ text: 'hello', translatable: true }],
+      target: 'it-IT',
+      instructions: ['  Translate   formally  ']
+    })).not.toThrow();
+  });
+
   it('should accept valid style values', () => {
     for (const style of ['faithful', 'fluid', 'creative']) {
       expect(() => translateSchema.parse({

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -142,7 +142,8 @@ async function ListTools() {
       {
         name: "translate",
         description:
-          "Translate text between languages with support for language detection, context-aware translations and translation memories using Lara Translate.",
+          "Translate text between languages using Lara Translate. Supports language detection, context-aware translations, translation memories, and glossaries. " +
+          "The optional 'instructions' parameter accepts short localization directives (e.g., 'Translate formally') — only provide them when the content specifically requires tone, formality, or terminology adjustments.",
         inputSchema: z.toJSONSchema(translateSchema),
       },
       {

--- a/src/mcp/tools/translate.ts
+++ b/src/mcp/tools/translate.ts
@@ -2,6 +2,8 @@ import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 import { logger } from "#logger";
 
+const MAX_INSTRUCTION_WORDS = 20;
+
 export const textBlockSchema = z.object({
   text: z.string(),
   translatable: z.boolean(),
@@ -31,10 +33,22 @@ export const translateSchema = z.object({
       "Additional context string to improve translation quality (e.g., 'This is a legal document' or 'Im talking with a doctor'). This helps the translation system better understand the domain."
     ),
   instructions: z
-    .array(z.string())
+    .array(
+      z.string()
+        .refine(
+          (s) => s.trim().split(/\s+/).length <= MAX_INSTRUCTION_WORDS,
+          { message: `Each instruction must be no more than ${MAX_INSTRUCTION_WORDS} words` }
+        )
+    )
     .optional()
     .describe(
-      "A list of instructions to adjust the network’s behavior regarding the output (e.g., 'Use a formal tone')."
+      `Optional list of short localization directives to adjust translation output. ` +
+      `Each instruction MUST be no more than ${MAX_INSTRUCTION_WORDS} words. ` +
+      `These are NOT free-form LLM prompts — they are expert localization directives about formality, tone, or domain-specific terminology. ` +
+      `Only provide instructions when the content specifically requires them; omitting instructions for general content preserves higher translation quality. ` +
+      `Do NOT combine contradictory instructions (e.g., formal and informal tone together). ` +
+      `Examples: ‘Translate formally’, ‘Use a creative and concise tone’, ‘Make translation gender-neutral’, ` +
+      `’Mask any price with the [price] placeholder’, ‘Use quotation marks (« ») for quotations’.`
     ),
   source_hint: z
     .string()

--- a/src/mcp/tools/translate.ts
+++ b/src/mcp/tools/translate.ts
@@ -47,8 +47,8 @@ export const translateSchema = z.object({
       `These are NOT free-form LLM prompts — they are expert localization directives about formality, tone, or domain-specific terminology. ` +
       `Only provide instructions when the content specifically requires them; omitting instructions for general content preserves higher translation quality. ` +
       `Do NOT combine contradictory instructions (e.g., formal and informal tone together). ` +
-      `Examples: ‘Translate formally’, ‘Use a creative and concise tone’, ‘Make translation gender-neutral’, ` +
-      `’Mask any price with the [price] placeholder’, ‘Use quotation marks (« ») for quotations’.`
+      `Examples: 'Translate formally', 'Use a creative and concise tone', 'Make translation gender-neutral', ` +
+      `'Mask any price with the [price] placeholder', 'Use quotation marks (« ») for quotations'.`
     ),
   source_hint: z
     .string()


### PR DESCRIPTION
## Summary
- Rewrote the `instructions` parameter description with best practices from the [Lara Translate docs](https://developers.laratranslate.com/docs/adapt-to-instructions) so LLMs understand that instructions are short localization directives (not free-form prompts), should be ≤20 words each, and should only be provided when content specifically requires tone/formality/terminology adjustments
- Added Zod `.refine()` validation enforcing the 20-word-per-instruction limit as a server-side safety net
- Updated the `translate` tool description to mention instructions usage guidelines upfront

## Test plan
- [x] All 157 tests pass (including 6 new instruction validation tests)
- [x] TypeScript build compiles without errors
- [x] Manual verification: connect an LLM client and confirm the improved descriptions lead to better instruction usage