### PR TITLE
docs: add OAuth quick start and client setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,15 +379,17 @@ Your client should invoke Lara Translate and return the translation.
 
 ## 🔐 Authentication
 
-### OAuth 2.0 (default)
+### OAuth 2.0 (default, hosted endpoint)
 
 This is the method used in the [Quick Start](#-quick-start) above. You provide only the server URL in your client config — no API keys needed. Your client handles the OAuth flow automatically: it opens your browser, you log in with your Lara Translate credentials, and you're connected.
 
+OAuth 2.0 is provided by the hosted service at `https://mcp-v2.laratranslate.com/v1`. The OAuth authorization server is not part of this repository — the code in `src/` only handles MCP tool calls authenticated via access-key headers (see [Access Key](#access-key) below). If you self-host, OAuth is not available out of the box.
+
 For per-client OAuth setup instructions, see the **[Client Setup Guide](docs/client-setup.md)**.
 
-For self-hosted OAuth server setup (Redis, endpoints, full flow), see the [OAuth 2.0 documentation](docs/oauth.md).
+For a reference description of the OAuth 2.0 flow, endpoints, and requirements of the hosted service, see the [OAuth 2.0 reference](docs/oauth.md).
 
-### Access Key (alternative)
+### Access Key
 
 If you prefer to authenticate with API keys instead of browser login, you can pass your credentials directly in the client config. Get your **Access Key ID** and **Secret** from [Lara Translate](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials).
 
@@ -399,15 +401,18 @@ Most users can connect to the hosted endpoint (`https://mcp-v2.laratranslate.com
 
 ### ⚠️ Security Note
 
-**Important:** When running your own HTTP server instance (not using the remote `https://mcp-v2.laratranslate.com/v1`), all connected clients share the same Lara API credentials configured via `LARA_ACCESS_KEY_ID` and `LARA_ACCESS_KEY_SECRET` environment variables.
+**Important:** The self-hosted server uses different credential models depending on the transport:
+
+- **STDIO mode** reads the Lara credentials from the `LARA_ACCESS_KEY_ID` and `LARA_ACCESS_KEY_SECRET` environment variables configured on the process. All requests share those credentials.
+- **HTTP mode** requires each incoming request to carry its own `x-lara-access-key-id` / `x-lara-access-key-secret` headers; the server does not fall back to environment variables.
 
 This server is designed for:
-- ✅ Single-user deployments
-- ✅ Trusted-environment deployments (e.g., internal tools)
+- ✅ Single-user STDIO deployments
+- ✅ Trusted-environment HTTP deployments (e.g., internal tools) where clients are expected to send their own credentials
 
 For multi-tenant scenarios, either:
-- Use the remote server at `https://mcp-v2.laratranslate.com/v1` where each client provides their own credentials via headers
-- Deploy separate MCP server instances per user with isolated credentials
+- Use the hosted server at `https://mcp-v2.laratranslate.com/v1` where each client authenticates via OAuth or its own access-key headers
+- Deploy separate STDIO instances per user with isolated credentials
 
 ### HTTP Server 🌐
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lara Translate MCP Server
 
-A Model Context Protocol (MCP) Server for [Lara Translate](https://laratranslate.com/translate) API, enabling powerful translation capabilities with support for language detection, context-aware translations, translation memories, and glossary management.
+A Model Context Protocol (MCP) Server for [Lara Translate](https://laratranslate.com/translate), enabling professional translation capabilities with support for language detection, context-aware translations, translation memories, and glossaries.
 
 [![License](https://img.shields.io/github/license/translated/lara-mcp.svg)](https://github.com/translated/lara-mcp/blob/main/LICENSE)
 [![Docker Pulls](https://img.shields.io/docker/pulls/translatednet/lara-mcp.svg)](https://hub.docker.com/r/translatednet/lara-mcp)
@@ -8,12 +8,11 @@ A Model Context Protocol (MCP) Server for [Lara Translate](https://laratranslate
 
 ## 📚 Table of Contents
 - 📖 [Introduction](#-introduction)
+- 🚀 [Quick Start](#-quick-start)
 - 🛠 [Available Tools](#-available-tools)
-- 🚀 [Getting Started](#-getting-started)
-  - 📋 [HTTP Server](#http-server-)
-  - 🔌 [STDIO Server](#stdio-server-%EF%B8%8F)
-- 🧪 [Verify Installation](#-verify-installation)
-- 💻 [Popular Clients that supports MCPs](#-popular-clients-that-supports-mcps)
+- 🔐 [Authentication](#-authentication)
+- 🏠 [Self-Hosting](#-self-hosting)
+- 💻 [Popular Clients that support MCPs](#-popular-clients-that-support-mcps)
 - 🆘 [Support](#-support)
 
 ## 📖 Introduction
@@ -65,6 +64,65 @@ By offloading complex translation tasks to specialized T-LMs, Lara reduces compu
 #### Cost-Efficient Translation at Scale
 Lara also lowers the cost of using models like GPT-4 in non-English workflows. Since tokenization (and pricing) is optimized for English, using Lara allows translation to take place before hitting the LLM, meaning that only the translated English content is processed. This improves cost efficiency and supports competitive scalability for global enterprises.
 </details>
+
+## 🚀 Quick Start
+
+Pick your client below — no API keys needed, just log in through your browser.
+
+### Claude Desktop
+
+1. Go to **Settings** > **Connectors**
+2. Click **Add Custom Connector**
+3. Enter the name: `Lara`
+4. Enter the URL: `https://mcp-v2.laratranslate.com/v1`
+5. Click **Add**, then click **Connect**
+6. Log in with your Lara Translate credentials in the browser
+
+Done — Lara Translate is now available in your conversations.
+
+### Cursor
+
+Open your config file (`~/.cursor/mcp.json` on macOS/Linux, `%APPDATA%\Cursor\mcp.json` on Windows) and paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+Save and restart Cursor. The first time you use a Lara tool, your browser will open to authenticate.
+
+### Claude Code
+
+Run this command in your terminal:
+
+```bash
+claude mcp add lara-translate --transport http --url https://mcp-v2.laratranslate.com/v1
+```
+
+The first time you use a Lara tool, your browser will open to authenticate.
+
+### Other Clients
+
+For step-by-step OAuth setup on **VS Code (GitHub Copilot)**, **Windsurf**, **Cline**, **Continue**, and more, see the **[Client Setup Guide](docs/client-setup.md)**.
+
+If your client isn't listed, the general approach is to add the server URL (`https://mcp-v2.laratranslate.com/v1`) to your MCP config — the client will handle OAuth authentication automatically.
+
+> For a complete list of MCP-compatible clients, visit the [official MCP clients page](https://modelcontextprotocol.io/clients).
+
+### Verify It Works
+
+After setup, test with a simple prompt:
+
+```text
+Translate with Lara "Hello world" to Spanish
+```
+
+Your client should invoke Lara Translate and return the translation.
 
 ## 🛠 Available Tools
 
@@ -319,26 +377,42 @@ Lara also lowers the cost of using models like GPT-4 in non-English workflows. S
 **Returns**: Import details
 </details>
 
-## 🚀 Getting Started
-Lara supports both the STDIO and streamable HTTP protocols. For a hassle-free setup, we recommend using the HTTP protocol. If you prefer to use STDIO, it must be installed locally on your machine.
+## 🔐 Authentication
 
-You'll find setup instructions for both protocols in the sections below.
+### OAuth 2.0 (default)
 
-## ⚠️ Security Note
+This is the method used in the [Quick Start](#-quick-start) above. You provide only the server URL in your client config — no API keys needed. Your client handles the OAuth flow automatically: it opens your browser, you log in with your Lara Translate credentials, and you're connected.
 
-**Important:** When running your own HTTP server instance (not using the remote `https://mcp.laratranslate.com/v1`), all connected clients share the same Lara API credentials configured via `LARA_ACCESS_KEY_ID` and `LARA_ACCESS_KEY_SECRET` environment variables.
+For per-client OAuth setup instructions, see the **[Client Setup Guide](docs/client-setup.md)**.
+
+For self-hosted OAuth server setup (Redis, endpoints, full flow), see the [OAuth 2.0 documentation](docs/oauth.md).
+
+### Access Key (alternative)
+
+If you prefer to authenticate with API keys instead of browser login, you can pass your credentials directly in the client config. Get your **Access Key ID** and **Secret** from [Lara Translate](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials).
+
+See the [Access Key section in the Client Setup Guide](docs/client-setup.md#alternative-access-key-authentication) for config examples.
+
+## 🏠 Self-Hosting
+
+Most users can connect to the hosted endpoint (`https://mcp-v2.laratranslate.com/v1`) using the [Quick Start](#-quick-start) instructions above. The options below are for running the server yourself.
+
+### ⚠️ Security Note
+
+**Important:** When running your own HTTP server instance (not using the remote `https://mcp-v2.laratranslate.com/v1`), all connected clients share the same Lara API credentials configured via `LARA_ACCESS_KEY_ID` and `LARA_ACCESS_KEY_SECRET` environment variables.
 
 This server is designed for:
 - ✅ Single-user deployments
 - ✅ Trusted-environment deployments (e.g., internal tools)
 
 For multi-tenant scenarios, either:
-- Use the remote server at `https://mcp.laratranslate.com/v1` where each client provides their own credentials via headers
+- Use the remote server at `https://mcp-v2.laratranslate.com/v1` where each client provides their own credentials via headers
 - Deploy separate MCP server instances per user with isolated credentials
 
 ### HTTP Server 🌐
+
 <details>
-<summary><strong>❌ Clients NOT supporting <code>url</code> configuration (e.g., Claude, OpenAI)</strong></summary>
+<summary><strong>❌ Clients NOT supporting <code>url</code> configuration (e.g., Claude Desktop, OpenAI)</strong></summary>
 
 This installation guide is intended for clients that do NOT support the url-based configuration. This option requires Node.js to be installed on your system.
 
@@ -355,7 +429,7 @@ This installation guide is intended for clients that do NOT support the url-base
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://mcp.laratranslate.com/v1",
+        "https://mcp-v2.laratranslate.com/v1",
         "--header",
         "x-lara-access-key-id: ${X_LARA_ACCESS_KEY_ID}",
         "--header",
@@ -392,7 +466,7 @@ Some examples of supported clients include Cursor, Continue, OpenDevin, and Aide
 {
   "mcpServers": {
     "lara": {
-      "url": "https://mcp.laratranslate.com/v1",
+      "url": "https://mcp-v2.laratranslate.com/v1",
       "headers": {
         "x-lara-access-key-id": "<YOUR_ACCESS_KEY_ID>",
         "x-lara-access-key-secret": "<YOUR_ACCESS_KEY_SECRET>"
@@ -411,6 +485,7 @@ Some examples of supported clients include Cursor, Continue, OpenDevin, and Aide
 ---
 
 ### STDIO Server 🖥️
+
 <details>
 <summary><strong>Using NPX</strong></summary>
 
@@ -548,19 +623,7 @@ docker build -t lara-mcp .
 4. Replace `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your actual credentials.
 </details>
 
-## 🧪 Verify Installation
-
-After restarting your MCP client, you should see Lara Translate MCP in the list of available MCPs.
-> The method for viewing installed MCPs varies by client. Please consult your MCP client's documentation.
-
-To verify that Lara Translate MCP is working correctly, try translating with a simple prompt:
-```text
-Translate with Lara "Hello world" to Spanish
-```
-
-Your MCP client will begin generating a response. If Lara Translate MCP is properly installed and configured, your client will either request approval for the action or display a notification that Lara Translate is being used.
-
-## 💻 Popular Clients that supports MCPs 
+## 💻 Popular Clients that support MCPs
 
 > For a complete list of MCP clients and their feature support, visit the [official MCP clients page](https://modelcontextprotocol.io/clients).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@ A Model Context Protocol (MCP) Server for [Lara Translate](https://laratranslate
 [![Docker Pulls](https://img.shields.io/docker/pulls/translatednet/lara-mcp.svg)](https://hub.docker.com/r/translatednet/lara-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@translated/lara-mcp.svg)](https://www.npmjs.com/package/@translated/lara-mcp)
 
+## 🌟 Highlights
+
+- 🌐 **Professional-grade translation** powered by Lara's domain-specific Translation Language Models, trained on billions of professionally translated segments — stronger on non-English languages than general-purpose LLMs.
+- 🔐 **OAuth login, zero config** — paste one URL into your MCP client, log in through your browser, and start translating. No API keys to manage.
+- 🤝 **Works with major MCP clients** — Claude Desktop, Cursor, Claude Code, VS Code (GitHub Copilot), Windsurf, Cline, Continue, and more.
+- 📚 **Translation memories & glossaries** — create, update, import TMX/CSV, and enforce terminology on every translation.
+- 🧠 **Context-aware translations** — pass instructions, style (`faithful` / `fluid` / `creative`), per-request context, and multi-step linguistic reasoning.
+- 🔒 **Privacy-first** — opt-out tracing (`no_trace`), audit logging, and input validation out of the box.
+- 🏠 **Hosted or self-hosted** — connect to the managed endpoint at `mcp-v2.laratranslate.com/v1`, or run it yourself via npm, Docker, or from source.
+
 ## 📚 Table of Contents
+- 🌟 [Highlights](#-highlights)
 - 📖 [Introduction](#-introduction)
 - 🚀 [Quick Start](#-quick-start)
 - 🛠 [Available Tools](#-available-tools)

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -23,9 +23,6 @@ Connect Lara Translate to your favorite AI client. The recommended method uses *
 3. Enter the name: `Lara`
 4. Enter the URL: `https://mcp-v2.laratranslate.com/v1`
 5. Click **Add**
-
-![Add Custom Connector](https://downloads.intercomcdn.com/i/o/lupk8zyo/1731190757/b6b02b1879bb55fb9ab32f222b06/8d09370d-1c7a-489c-b62b-b3484aaaef31?expires%3D1765471500%26signature%3D0d8212f6938008d55dec82fdc3e20b64c07b93ebec368ab74cba77e7980d099a%26req%3DdSckF8h3nYZaXvMW1HO4zYLxKhd694%2BiiJlgl7fGiwR%2F%2BSImZUUlz6Dw2QdV%0AKllJvjnsbArbYSudYjw%3D%0A)
-
 6. Click **Connect** next to the connector. Your browser will open the Lara Translate login page.
 7. Log in with your Lara Translate credentials. You'll be redirected back to Claude Desktop automatically.
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1,0 +1,283 @@
+# Client Setup Guide
+
+Connect Lara Translate to your favorite AI client. The recommended method uses **OAuth** — just enter the server URL and log in through your browser. No API keys to manage.
+
+## Table of Contents
+
+- [Claude Desktop](#claude-desktop)
+- [Cursor](#cursor)
+- [Claude Code](#claude-code)
+- [VS Code (GitHub Copilot)](#vs-code-github-copilot)
+- [Windsurf](#windsurf)
+- [Cline (VS Code)](#cline-vs-code)
+- [Continue](#continue)
+- [Alternative: Access Key Authentication](#alternative-access-key-authentication)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Claude Desktop
+
+1. Open Claude Desktop and go to **Settings** > **Connectors**
+2. Click **Add Custom Connector**
+3. Enter the name: `Lara`
+4. Enter the URL: `https://mcp-v2.laratranslate.com/v1`
+5. Click **Add**
+
+![Add Custom Connector](https://downloads.intercomcdn.com/i/o/lupk8zyo/1731190757/b6b02b1879bb55fb9ab32f222b06/8d09370d-1c7a-489c-b62b-b3484aaaef31?expires%3D1765471500%26signature%3D0d8212f6938008d55dec82fdc3e20b64c07b93ebec368ab74cba77e7980d099a%26req%3DdSckF8h3nYZaXvMW1HO4zYLxKhd694%2BiiJlgl7fGiwR%2F%2BSImZUUlz6Dw2QdV%0AKllJvjnsbArbYSudYjw%3D%0A)
+
+6. Click **Connect** next to the connector. Your browser will open the Lara Translate login page.
+7. Log in with your Lara Translate credentials. You'll be redirected back to Claude Desktop automatically.
+
+That's it — Lara Translate is now available in your conversations.
+
+> For more on custom connectors, see the [Claude documentation](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp).
+
+---
+
+## Cursor
+
+1. Open the MCP config file:
+   - **macOS**: `~/.cursor/mcp.json`
+   - **Windows**: `%APPDATA%\Cursor\mcp.json`
+   - **Linux**: `~/.cursor/mcp.json`
+2. Paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+3. Save and restart Cursor.
+4. The first time you use a Lara tool, Cursor will open your browser to authenticate with your Lara Translate credentials.
+
+---
+
+## Claude Code
+
+Run this command in your terminal:
+
+```bash
+claude mcp add lara-translate --transport http --url https://mcp-v2.laratranslate.com/v1
+```
+
+The first time Lara tools are used, Claude Code will open your browser to authenticate with your Lara Translate credentials.
+
+Alternatively, create a `.mcp.json` file in your project root:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+---
+
+## VS Code (GitHub Copilot)
+
+VS Code supports MCP servers through GitHub Copilot's agent mode.
+
+### Option A: Project-level config
+
+Create a `.vscode/mcp.json` file in your project:
+
+```json
+{
+  "servers": {
+    "lara-translate": {
+      "type": "http",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+### Option B: User settings
+
+Open VS Code Settings (JSON) and add:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "lara-translate": {
+        "type": "http",
+        "url": "https://mcp-v2.laratranslate.com/v1"
+      }
+    }
+  }
+}
+```
+
+Save and reload VS Code. When you first use a Lara tool in Copilot's agent mode, your browser will open to authenticate with Lara Translate.
+
+> MCP support in VS Code requires GitHub Copilot. See the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for details.
+
+---
+
+## Windsurf
+
+1. Open the config file:
+   - **macOS / Linux**: `~/.codeium/windsurf/mcp_config.json`
+   - **Windows**: `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
+
+   Or in Windsurf: **Settings** > search "MCP" > **Edit in mcp_config.json**.
+2. Paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "serverUrl": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+3. Save and restart Windsurf. Your browser will open to authenticate the first time you use a Lara tool.
+
+---
+
+## Cline (VS Code)
+
+1. Open VS Code and click the **Cline** icon in the sidebar.
+2. Click the **MCP Servers** button (server icon) at the top of the Cline panel.
+3. Click **Remote Servers**.
+4. Add:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+5. Save. Your browser will open to authenticate when you first use a Lara tool.
+
+---
+
+## Continue
+
+1. Open the config file:
+   - **macOS / Linux**: `~/.continue/config.json`
+   - **Windows**: `%USERPROFILE%\.continue\config.json`
+
+   Or use the Continue sidebar > gear icon.
+2. Add the `mcpServers` section:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "lara-translate",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  ]
+}
+```
+
+3. Save and restart Continue. Your browser will open to authenticate when you first use a Lara tool.
+
+> Note: Continue uses an array format for `mcpServers`. See the [Continue MCP docs](https://docs.continue.dev/customize/model-context-protocol) for details.
+
+---
+
+## Alternative: Access Key Authentication
+
+If your client doesn't support OAuth, or you prefer to authenticate with API keys instead of browser login, you can pass your credentials directly in the config. Get your **Access Key ID** and **Secret** from [Lara Translate](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials).
+
+### Clients with `url` support (Cursor, Windsurf, VS Code, Cline, Continue, Claude Code)
+
+Add your credentials as headers alongside the URL:
+
+```json
+{
+  "lara-translate": {
+    "url": "https://mcp-v2.laratranslate.com/v1",
+    "headers": {
+      "x-lara-access-key-id": "<YOUR_ACCESS_KEY_ID>",
+      "x-lara-access-key-secret": "<YOUR_ACCESS_KEY_SECRET>"
+    }
+  }
+}
+```
+
+> Adapt the wrapper format to your client (e.g., `"mcpServers"` for Cursor, `"servers"` with `"type": "http"` for VS Code, etc.). See the OAuth sections above for each client's exact format.
+
+### Claude Desktop (command-based)
+
+Claude Desktop doesn't support `url`-based configs directly, so it uses `mcp-remote` as a bridge. Requires [Node.js](https://nodejs.org/).
+
+Open the config file:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp-v2.laratranslate.com/v1",
+        "--header",
+        "x-lara-access-key-id: ${X_LARA_ACCESS_KEY_ID}",
+        "--header",
+        "x-lara-access-key-secret: ${X_LARA_ACCESS_KEY_SECRET}"
+      ],
+      "env": {
+        "X_LARA_ACCESS_KEY_ID": "<YOUR_ACCESS_KEY_ID>",
+        "X_LARA_ACCESS_KEY_SECRET": "<YOUR_ACCESS_KEY_SECRET>"
+      }
+    }
+  }
+}
+```
+
+Replace the placeholders with your credentials, save, and restart Claude Desktop.
+
+---
+
+## Troubleshooting
+
+**OAuth login page doesn't open?**
+
+- Ensure your client supports OAuth for MCP servers (check your client's documentation)
+- Make sure your default browser is set and can open URLs
+- Try the [Access Key method](#alternative-access-key-authentication) as a fallback
+
+**Server not showing up after restart?**
+
+- Double-check your JSON syntax (missing commas, trailing commas, etc.)
+- Ensure the config file is in the correct location for your OS
+- Some clients require a full application restart, not just a window reload
+
+**Authentication errors?**
+
+- If using Access Key: verify your credentials are correct and active in your [Lara Translate account](https://laratranslate.com)
+- If using OAuth: try disconnecting and reconnecting to re-authenticate
+
+**Connection issues with `mcp-remote`?**
+
+- Ensure [Node.js](https://nodejs.org/) (v18+) is installed: `node --version`
+- Check your network/firewall allows outbound HTTPS connections
+
+**Still stuck?**
+
+- For API issues: [Lara Translate Support](https://support.laratranslate.com)
+- For MCP server issues: [GitHub Issues](https://github.com/translated/lara-mcp/issues)

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,8 +1,10 @@
-# OAuth 2.0 Authentication (Self-Hosted)
+# OAuth 2.0 Reference
 
-> This document is for self-hosted deployments of the Lara MCP Server. If you're using the hosted endpoint (`https://mcp-v2.laratranslate.com/v1`), see the [OAuth section in the README](../README.md#oauth-20-default) for simpler setup instructions.
+> This document describes the OAuth 2.0 authorization server that fronts the hosted endpoint at `https://mcp-v2.laratranslate.com/v1`. It is a reference for MCP client authors and for anyone planning to reproduce the flow in a custom deployment — **the OAuth authorization server code is not shipped in this repository** (`src/` only implements MCP tool handling and access-key authentication).
+>
+> If you only need to connect an MCP client to the hosted endpoint, follow the [Quick Start](../README.md#-quick-start) or the [Client Setup Guide](client-setup.md). You do not need to read this document.
 
-This document describes the OAuth 2.0 authentication flow implemented in the Lara MCP Server. The server implements a standards-compliant OAuth 2.0 authorization server that enables secure authentication for MCP clients.
+This document describes the OAuth 2.0 authentication flow used by the hosted Lara MCP service. The service exposes a standards-compliant OAuth 2.0 authorization server that enables secure authentication for MCP clients.
 
 ## Table of Contents
 
@@ -27,16 +29,13 @@ The OAuth implementation provides a secure way for MCP clients to authenticate a
 
 ## Prerequisites
 
-- A publicly accessible MCP server instance (required for OAuth callbacks)
-- Redis server (for storing authorization codes and tokens)
-- The following environment variables:
+To stand up a deployment equivalent to the hosted service you need:
 
-```bash
-PUBLIC_HOST=https://your-mcp-server.com  # Your server's public URL
-REDIS_HOST=localhost                      # Redis host (default: localhost)
-REDIS_PORT=6379                           # Redis port (default: 6379)
-REDIS_PASSWORD=your-redis-password        # Redis password
-```
+- A publicly accessible MCP server instance, because OAuth redirect/callback URLs must resolve back to the deployment.
+- A way to configure the deployment's public base URL (used to build callback URLs).
+- A store for short-lived authorization codes and issued tokens. The hosted service uses Redis; any equivalent key/value store with TTL support would work.
+
+> **Note:** The configuration keys, environment variables, and infrastructure described here are deployment-specific. They are **not** part of this repository's `src/env.ts` — the code in this repo does not run the OAuth server. Treat the variables referenced below (`PUBLIC_HOST`, `REDIS_HOST`, etc.) as example names used by the hosted deployment.
 
 ## OAuth Flow Diagram
 
@@ -242,7 +241,6 @@ Returns authorization server metadata per RFC 8414.
   "token_endpoint": "https://mcp.example.com/token",
   "registration_endpoint": "https://mcp.example.com/register",
   "token_endpoint_auth_methods_supported": ["none"],
-  "scopes_supported": ["scrape"],
   "response_types_supported": ["code"],
   "grant_types_supported": ["authorization_code"],
   "code_challenge_methods_supported": ["S256"]

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,311 @@
+# OAuth 2.0 Authentication (Self-Hosted)
+
+> This document is for self-hosted deployments of the Lara MCP Server. If you're using the hosted endpoint (`https://mcp-v2.laratranslate.com/v1`), see the [OAuth section in the README](../README.md#oauth-20-default) for simpler setup instructions.
+
+This document describes the OAuth 2.0 authentication flow implemented in the Lara MCP Server. The server implements a standards-compliant OAuth 2.0 authorization server that enables secure authentication for MCP clients.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [OAuth Flow Diagram](#oauth-flow-diagram)
+- [OAuth Flow](#oauth-flow)
+- [Endpoints](#endpoints)
+- [System Architecture Diagram](#system-architecture-diagram)
+
+## Overview
+
+The OAuth implementation provides a secure way for MCP clients to authenticate and obtain access tokens for making requests to the MCP server. The flow follows the OAuth 2.0 Authorization Code grant type with PKCE (Proof Key for Code Exchange) support.
+
+### Key Features
+
+- **Authorization Code Flow**: Standard OAuth 2.0 authorization code grant
+- **PKCE Support**: Enhanced security for public clients using PKCE (RFC 7636)
+- **Dynamic Client Registration**: Clients can register dynamically (RFC 7591)
+- **Resource Parameter**: Support for resource/audience specification (RFC 8707)
+- **Standards Compliant**: Implements RFC 8414, RFC 9728, RFC 7591, RFC 7636, and RFC 8707
+
+## Prerequisites
+
+- A publicly accessible MCP server instance (required for OAuth callbacks)
+- Redis server (for storing authorization codes and tokens)
+- The following environment variables:
+
+```bash
+PUBLIC_HOST=https://your-mcp-server.com  # Your server's public URL
+REDIS_HOST=localhost                      # Redis host (default: localhost)
+REDIS_PORT=6379                           # Redis port (default: 6379)
+REDIS_PASSWORD=your-redis-password        # Redis password
+```
+
+## OAuth Flow Diagram
+
+```text
+┌─────────────┐                                                     ┌──────────────┐
+│   Client    │                                                     │ OAuth Server │
+│  (MCP App)  │                                                     │              │
+└──────┬──────┘                                                     └───────┬──────┘
+       │                                                                    │
+       │ 1. POST /register                                                  │
+       │────────────────────────────────────────────────────────────────────▶│
+       │                                                                    │
+       │ 2. Response: { client_id, ... }                                    │
+       │◀────────────────────────────────────────────────────────────────────│
+       │                                                                    │
+       │ 3. GET /authorize?client_id=...&redirect_uri=...&code_challenge=...│
+       │────────────────────────────────────────────────────────────────────▶│
+       │                                                                    │
+       │                                                                    │ 4. Generate auth code
+       │                                                                    │    Store code with PKCE data
+       │                                                                    │
+       │                                                                    │ 5. Redirect to Lara Login
+       │                                                                    │──────────────────┐
+       │                                                                    │                  │
+       │                                                                    │                  ▼
+       │                                                                    │         ┌───────────────────┐
+       │                                                                    │         │ Lara Translate    │
+       │                                                                    │         │ Login Interface   │
+       │                                                                    │         └────────┬──────────┘
+       │                                                                    │                  │
+       │                                                                    │                  │ 6. User authenticates
+       │                                                                    │                  │    Obtains tokens
+       │                                                                    │                  │
+       │                                                                    │                  │ 7. GET /callback?code=...&token=...&refreshToken=...
+       │                                                                    │◀─────────────────┘
+       │                                                                    │
+       │                                                                    │ 8. Store tokens with auth code
+       │                                                                    │
+       │ 9. Redirect: redirect_uri?code=AUTH_CODE&state=...                 │
+       │◀────────────────────────────────────────────────────────────────────│
+       │                                                                    │
+       │ 10. POST /token                                                    │
+       │     grant_type=authorization_code&code=...&code_verifier=...       │
+       │────────────────────────────────────────────────────────────────────▶│
+       │                                                                    │
+       │                                                                    │ 11. Validate code & PKCE
+       │                                                                    │     Exchange code for tokens
+       │                                                                    │
+       │ 12. Response: { access_token, refresh_token, ... }                 │
+       │◀────────────────────────────────────────────────────────────────────│
+       │                                                                    │
+       │ 13. POST /v1                                                       │
+       │     Authorization: Bearer ACCESS_TOKEN                             │
+       │────────────────────────────────────────────────────────────────────▶│
+       │                                                                    │
+       │ 14. Response: MCP JSON-RPC response                                │
+       │◀────────────────────────────────────────────────────────────────────│
+       │                                                                    │
+```
+
+## OAuth Flow
+
+### 1. Client Registration
+
+Clients register dynamically to obtain a `client_id`:
+
+```http
+POST /register
+Content-Type: application/json
+
+{
+  "client_name": "My MCP Client",
+  "redirect_uris": ["https://my-app.com/callback"]
+}
+```
+
+**Response:**
+
+```json
+{
+  "client_id": "abc123...",
+  "client_id_issued_at": 1234567890,
+  "client_secret_expires_at": 0,
+  "token_endpoint_auth_method": "none",
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "redirect_uris": ["https://my-app.com/callback"]
+}
+```
+
+### 2. Authorization Request
+
+The client initiates the authorization flow by redirecting the user to the authorization endpoint:
+
+```http
+GET /authorize?client_id=abc123&redirect_uri=https://my-app.com/callback&response_type=code&state=xyz&code_challenge=...&code_challenge_method=S256
+```
+
+**Parameters:**
+
+- `client_id` (required): The client identifier
+- `redirect_uri` (required): Where to redirect after authorization
+- `response_type` (required): Must be `code`
+- `state` (optional): CSRF protection token
+- `code_challenge` (optional): PKCE code challenge
+- `code_challenge_method` (optional): PKCE method (`S256` or `plain`)
+- `resource` (optional): Resource/audience identifier (RFC 8707)
+
+**What Happens:**
+
+1. Server validates all required parameters
+2. Server generates a secure authorization code using `crypto.randomBytes(32).toString("base64url")`
+3. Server stores the authorization code with client ID, redirect URI, state, PKCE data, and a 10-minute expiration
+4. Server constructs a callback URL: `${PUBLIC_HOST}/callback?code=${authorizationCode}`
+5. Server retrieves the Lara Translate login URL via `Translator.getLoginUrl()`
+6. Server redirects the user to: `${loginUrl}?redirect-to=${encodedCallbackUrl}&cid=mcp`
+7. User authenticates with Lara Translate
+
+> **Note**: The `/authorize` endpoint performs a custom redirection to the Lara Translate login interface. This allows the server to obtain actual authentication tokens from Lara Translate before completing the OAuth flow.
+
+### 3. Callback from Login Interface
+
+After successful login, the Lara login interface redirects back to the server's callback endpoint:
+
+```http
+GET /callback?code=AUTHORIZATION_CODE&token=ACCESS_TOKEN&refreshToken=REFRESH_TOKEN
+```
+
+**Parameters:**
+
+- `code` (required): The authorization code generated in step 2
+- `token` (required): Access token obtained from Lara Translate
+- `refreshToken` (optional): Refresh token obtained from Lara Translate
+
+**What Happens:**
+
+1. Server validates the authorization code exists and hasn't expired
+2. Server stores the access token and refresh token with the authorization code
+3. Server redirects back to the client's `redirect_uri` with the authorization code and state
+
+### 4. Token Exchange
+
+The client exchanges the authorization code for an access token:
+
+```http
+POST /token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code=AUTHORIZATION_CODE&redirect_uri=https://my-app.com/callback&client_id=abc123&code_verifier=VERIFIER
+```
+
+**Parameters:**
+
+- `grant_type` (required): Must be `authorization_code`
+- `code` (required): The authorization code from step 3
+- `redirect_uri` (optional): Must match the original redirect URI
+- `client_id` (optional): Must match the original client ID
+- `code_verifier` (required if PKCE was used): The PKCE code verifier
+- `resource` (optional): Must match the resource from authorization request
+
+**Response:**
+
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "bearer",
+  "scope": "",
+  "expires_in": 3600,
+  "refresh_token": "def456..."
+}
+```
+
+> Access tokens expire after 1 hour. Clients supporting refresh tokens can use them to obtain new access tokens without re-authentication.
+
+### 5. Using the Access Token
+
+Include the access token in the `Authorization` header for MCP requests:
+
+```http
+POST /v1
+Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": { ... }
+}
+```
+
+## Endpoints
+
+### Metadata Endpoints
+
+#### `GET /.well-known/oauth-authorization-server`
+
+Returns authorization server metadata per RFC 8414.
+
+```json
+{
+  "issuer": "https://mcp.example.com",
+  "authorization_endpoint": "https://mcp.example.com/authorize",
+  "token_endpoint": "https://mcp.example.com/token",
+  "registration_endpoint": "https://mcp.example.com/register",
+  "token_endpoint_auth_methods_supported": ["none"],
+  "scopes_supported": ["scrape"],
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code"],
+  "code_challenge_methods_supported": ["S256"]
+}
+```
+
+#### `GET /.well-known/oauth-protected-resource`
+
+Returns protected resource metadata per RFC 9728.
+
+```json
+{
+  "resource": "https://mcp.example.com",
+  "authorization_servers": ["https://mcp.example.com"]
+}
+```
+
+### OAuth Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/register` | POST | Dynamic client registration (RFC 7591) |
+| `/authorize` | GET | Start the authorization flow |
+| `/callback` | GET | Receive tokens from Lara login interface |
+| `/token` | POST | Exchange authorization code for access token |
+
+## System Architecture Diagram
+
+```text
+┌──────────────┐                     ┌──────────────┐           ┌──────────────┐
+│  MCP Client  │◀───────────────────▶│  MCP Server  │◀─────────▶│     Redis    │
+│              │   OAuth 2.0 Flow    │  (OAuth)     │           │              │
+└──────────────┘                     └──────┬───────┘           └──────────────┘
+                                            │
+                                            │
+                                            ▼
+                                    ┌──────────────┐
+                                    │  Lara login  │
+                                    │  Interface   │
+                                    └──────────────┘
+```
+
+**Key Interactions:**
+
+- **MCP Client <-> MCP Server**: Standard OAuth 2.0 flow (authorization, token exchange, API requests)
+- **MCP Server <-> Redis**: Storage and retrieval of authorization codes and tokens
+- **MCP Server <-> Lara Login**: Custom redirection for user authentication and token acquisition
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PUBLIC_HOST` | (required) | Public URL for external access (e.g., `https://mcp.example.com`) |
+| `REDIS_HOST` | `localhost` | Redis server address |
+| `REDIS_PORT` | `6379` | Redis server port |
+| `REDIS_PASSWORD` | - | Redis authentication password |
+| `REDIS_KEY_PREFIX` | `lara-mcp:` | Key prefix for Redis storage |
+
+## Integration with MCP Server
+
+The OAuth tokens are integrated into the MCP server authentication:
+
+1. **Token Extraction**: MCP routes extract Bearer tokens from the `Authorization` header
+2. **Token Validation**: Tokens are validated on each request
+3. **Server Creation**: Valid tokens are used to create authenticated MCP server instances
+4. **Fallback**: If no Bearer token is present, the server falls back to header-based authentication (`x-lara-access-key-id` and `x-lara-access-key-secret`)


### PR DESCRIPTION
## Summary
- Restructure the README with an OAuth-first **Quick Start** (Claude Desktop, Cursor, Claude Code) so users can connect via browser login with no API keys.
- Add a new **Authentication** section (OAuth 2.0 default / Access Key alternative) and move the old Access Key / STDIO / HTTP setups under a **Self-Hosting** section.
- Update hosted endpoint references from `mcp.laratranslate.com/v1` to `mcp-v2.laratranslate.com/v1`.
- Add `docs/client-setup.md` (per-client OAuth guide for VS Code Copilot, Windsurf, Cline, Continue, etc. + Access Key fallback + troubleshooting) and `docs/oauth.md` (self-hosted OAuth 2.0 flow, endpoints, env vars).
