### PR TITLE
1.0.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,12 @@
 /.github/
 /ops/
 
+# Claude Code plugin (distributed via the Anthropic marketplace, not npm)
+/plugin/
+
+# User-facing docs (lives on GitHub, not in the npm tarball)
+/docs/
+
 # Docker
 Dockerfile
 .dockerignore

--- a/README.md
+++ b/README.md
@@ -1,422 +1,146 @@
 # Lara Translate MCP Server
 
-A Model Context Protocol (MCP) Server for [Lara Translate](https://laratranslate.com/translate) API, enabling powerful translation capabilities with support for language detection, context-aware translations, translation memories, and glossary management.
+A Model Context Protocol (MCP) server for [Lara Translate](https://laratranslate.com/translate), enabling professional translation capabilities with support for language detection, context-aware translations, translation memories, and glossaries.
+
+Lara leverages Translation Language Models (T-LMs) trained on billions of professionally translated segments, delivering domain-specific translations that capture cultural nuances and industry terminology that general-purpose LLMs often miss.
 
 [![License](https://img.shields.io/github/license/translated/lara-mcp.svg)](https://github.com/translated/lara-mcp/blob/main/LICENSE)
 [![Docker Pulls](https://img.shields.io/docker/pulls/translatednet/lara-mcp.svg)](https://hub.docker.com/r/translatednet/lara-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@translated/lara-mcp.svg)](https://www.npmjs.com/package/@translated/lara-mcp)
 
-## 📚 Table of Contents
-- 📖 [Introduction](#-introduction)
-- 🛠 [Available Tools](#-available-tools)
-- 🚀 [Getting Started](#-getting-started)
-  - 📋 [HTTP Server](#http-server-)
-  - 🔌 [STDIO Server](#stdio-server-%EF%B8%8F)
-- 🧪 [Verify Installation](#-verify-installation)
-- 💻 [Popular Clients that supports MCPs](#-popular-clients-that-supports-mcps)
-- 🆘 [Support](#-support)
+## Quick Start
 
-## 📖 Introduction
+Pick your client below — no API keys needed, just log in through your browser.
 
-<details>
-<summary><strong>What is MCP?</strong></summary>
+### Claude Desktop
 
-Model Context Protocol (MCP) is an open standardized communication protocol that enables AI applications to connect with external tools, data sources, and services. Think of MCP like a USB-C port for AI applications - just as USB-C provides a standardized way to connect devices to various peripherals, MCP provides a standardized way to connect AI models to different data sources and tools.
+1. Go to **Settings** > **Connectors**
+2. Click **Add Custom Connector**
+3. Enter the name: `Lara`
+4. Enter the URL: `https://mcp-v2.laratranslate.com/v1`
+5. Click **Add**, then click **Connect**
+6. Log in with your Lara Translate credentials in the browser
 
-Lara Translate MCP Server enables AI applications to access Lara Translate's powerful translation capabilities through this standardized protocol.
+Done — Lara Translate is now available in your conversations.
 
-> More info about Model Context Protocol on: https://modelcontextprotocol.io/
-</details>
+### Cursor
 
-<details>
-<summary><strong>How Lara Translate MCP Works</strong></summary>
-
-Lara Translate MCP Server implements the Model Context Protocol to provide seamless translation capabilities to AI applications. The integration follows this flow:
-
-1. **Connection Establishment**: When an MCP-compatible AI application starts, it connects to configured MCP servers, including the Lara Translate MCP Server
-2. **Tool & Resource Discovery**: The AI application discovers available translation tools and resources provided by the Lara Translate MCP Server
-3. **Request Processing**: When translation needs are identified:
-   - The AI application formats a structured request with text to translate, language pairs, and optional context
-   - The MCP server validates the request and transforms it into Lara Translate API calls
-   - The request is securely sent to Lara Translate's API using your credentials
-4. **Translation & Response**: Lara Translate processes the translation using advanced AI models
-5. **Result Integration**: The translation results are returned to the AI application, which can then incorporate them into its response
-
-This integration architecture allows AI applications to access professional-grade translations without implementing the API directly, while maintaining the security of your API credentials and offering flexibility to adjust translation parameters through natural language instructions.
-</details>
-
-<details>
-<summary><strong>Why to use Lara inside an LLM</strong></summary>
-
-Integrating Lara with LLMs creates a powerful synergy that significantly enhances translation quality for non-English languages.
-
-#### Why General LLMs Fall Short in Translation
-While large language models possess broad linguistic capabilities, they often lack the specialized expertise and up-to-date terminology required for accurate translations in specific domains and languages.
-
-#### Lara’s Domain-Specific Advantage
-Lara overcomes this limitation by leveraging Translation Language Models (T-LMs) trained on billions of professionally translated segments. These models provide domain-specific machine translation that captures cultural nuances and industry terminology that generic LLMs may miss. The result: translations that are contextually accurate and sound natural to native speakers.
-
-#### Designed for Non-English Strength
-Lara has a strong focus on non-English languages, addressing the performance gap found in models such as GPT-4. The dominance of English in datasets such as Common Crawl and Wikipedia results in lower quality output in other languages. Lara helps close this gap by providing higher quality understanding, generation, and restructuring in a multilingual context.
-
-#### Faster, Smarter Multilingual Performance
-By offloading complex translation tasks to specialized T-LMs, Lara reduces computational overhead and minimizes latency—a common issue for LLMs handling non-English input. Its architecture processes translations in parallel with the LLM, enabling for real-time, high-quality output without compromising speed or efficiency.
-
-#### Cost-Efficient Translation at Scale
-Lara also lowers the cost of using models like GPT-4 in non-English workflows. Since tokenization (and pricing) is optimized for English, using Lara allows translation to take place before hitting the LLM, meaning that only the translated English content is processed. This improves cost efficiency and supports competitive scalability for global enterprises.
-</details>
-
-## 🛠 Available Tools
-
-### Translation Tools
-
-<details>
-<summary><strong>translate</strong> - Translate text between languages</summary>
-
-**Inputs**:
-- `text` (array): An array of text blocks to translate, each with:
-    - `text` (string): The text content
-    - `translatable` (boolean): Whether this block should be translated
-- `source` (optional string): Source language code (e.g., 'en-EN')
-- `target` (string): Target language code (e.g., 'it-IT')
-- `context` (optional string): Additional context to improve translation quality
-- `instructions` (optional string[]): Instructions to adjust translation behavior
-- `source_hint` (optional string): Guidance for language detection
-- `glossaries` (optional string[]): Array of glossary IDs to enforce terminology (e.g., ['gls_xyz123'])
-- `no_trace` (optional boolean): Privacy flag - if true, request won't be traced/logged
-- `priority` (optional string): Translation priority - 'normal' or 'background'
-- `timeout_in_millis` (optional number): Custom timeout in milliseconds (max 300000)
-- `adapt_to` (optional string[]): Translation memory IDs for adapting the translation
-- `style` (optional string): Translation style - 'faithful', 'fluid', or 'creative'
-- `reasoning` (optional boolean): Enables Lara Think multi-step linguistic analysis
-- `content_type` (optional string): Content type - 'text/plain', 'text/html', or 'application/xliff+xml'
-
-**Returns**: Translated text blocks maintaining the original structure
-</details>
-
-<details>
-<summary><strong>detect_language</strong> - Detect the language of a text</summary>
-
-**Inputs**:
-- `text` (string | string[]): Text or array of texts to detect (max 128 elements)
-- `hint` (optional string): Hint for language detection
-- `passlist` (optional string[]): Array of language codes to restrict detection to
-
-**Returns**: Detected language, content type, and predictions with confidence scores
-</details>
-
-<details>
-<summary><strong>list_languages</strong> - List supported languages</summary>
-
-**Inputs**: None
-
-**Returns**: Array of supported languages
-</details>
-
-### Glossaries Tools
-
-<details>
-<summary><strong>list_glossaries</strong> - List all glossaries</summary>
-
-**Inputs**: None
-
-**Returns**: Array of glossaries with their details (id, name, createdAt, updatedAt, ownerId)
-</details>
-
-<details>
-<summary><strong>get_glossary</strong> - Get a specific glossary by ID</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-
-**Returns**: Glossary object or null if not found
-</details>
-
-<details>
-<summary><strong>create_glossary</strong> - Create a new glossary</summary>
-
-**Inputs**:
-- `name` (string): Name of the glossary (max 250 characters)
-
-**Returns**: Created glossary data
-</details>
-
-<details>
-<summary><strong>update_glossary</strong> - Update a glossary</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-- `name` (string): New name for the glossary (max 250 characters)
-
-**Returns**: Updated glossary data
-</details>
-
-<details>
-<summary><strong>delete_glossary</strong> - Delete a glossary</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-
-**Returns**: Deleted glossary data
-</details>
-
-<details>
-<summary><strong>get_glossary_counts</strong> - Get term and language counts for a glossary</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-
-**Returns**: Term and language counts
-</details>
-
-<details>
-<summary><strong>add_glossary_entry</strong> - Add an entry to a glossary</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-- `terms` (array): Array of terms, each with:
-    - `language` (string): Language code
-    - `value` (string): Term value
-- `guid` (optional string): Unique identifier for the entry
-
-**Returns**: Created glossary entry data
-</details>
-
-<details>
-<summary><strong>delete_glossary_entry</strong> - Delete an entry from a glossary</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-- `term` (optional object): Term to delete, with:
-    - `language` (string): Language code
-    - `value` (string): Term value
-- `guid` (optional string): Unique identifier of the entry to delete
-
-> At least one of `term` or `guid` must be provided.
-
-**Returns**: Deletion confirmation
-</details>
-
-<details>
-<summary><strong>import_glossary_csv</strong> - Import a CSV file into a glossary</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-- `csv_content` (string): The CSV file content (max 5MB)
-- `content_type` (optional string): CSV format - 'csv/table-uni' (default) or 'csv/table-multi'
-- `gzip` (optional boolean): Indicates if the content is gzip compressed
-
-**Returns**: Import job details with import ID
-</details>
-
-<details>
-<summary><strong>check_glossary_import_status</strong> - Check the status of a glossary CSV import</summary>
-
-**Inputs**:
-- `id` (string): The import job ID
-
-**Returns**: Import job status with progress information
-</details>
-
-<details>
-<summary><strong>export_glossary</strong> - Export a glossary as CSV</summary>
-
-**Inputs**:
-- `id` (string): The glossary ID (e.g., 'gls_xyz123')
-- `content_type` (string): Export format - 'csv/table-uni' or 'csv/table-multi'
-- `source` (optional string): Source language code (required when content_type is 'csv/table-uni')
-
-**Returns**: Exported glossary CSV content
-</details>
-
-### Translation Memories Tools
-
-<details>
-
-<summary><strong>list_memories</strong> - List saved translation memories</summary>
-
-**Returns**: Array of memories and their details
-</details>
-
-<details>
-<summary><strong>create_memory</strong> - Create a new translation memory</summary>
-
-**Inputs**:
-- `name` (string): Name of the new memory
-- `external_id` (optional string): ID of the memory to import from MyMemory (e.g., 'ext_my_[MyMemory ID]')
-
-**Returns**: Created memory data
-</details>
-
-<details>
-<summary><strong>update_memory</strong> - Update translation memory name</summary>
-
-**Inputs**:
-- `id` (string): ID of the memory to update
-- `name` (string): The new name for the memory
-
-**Returns**: Updated memory data
-</details>
-
-<details>
-<summary><strong>delete_memory</strong> - Delete a translation memory</summary>
-
-**Inputs**:
-- `id` (string): ID of the memory to delete
-
-**Returns**: Deleted memory data
-</details>
-
-<details>
-<summary><strong>add_translation</strong> - Add a translation unit to memory</summary>
-
-**Inputs**:
-- `id` (string | string[]): ID or IDs of memories where to add the translation unit
-- `source` (string): Source language code
-- `target` (string): Target language code
-- `sentence` (string): The source sentence
-- `translation` (string): The translated sentence
-- `tuid` (optional string): Translation Unit unique identifier
-- `sentence_before` (optional string): Context sentence before
-- `sentence_after` (optional string): Context sentence after
-
-**Returns**: Added translation details
-</details>
-
-<details>
-<summary><strong>delete_translation</strong> - Delete a translation unit from memory</summary>
-
-**Inputs**:
-- `id` (string): ID of the memory
-- `source` (string): Source language code
-- `target` (string): Target language code
-- `sentence` (string): The source sentence
-- `translation` (string): The translated sentence
-- `tuid` (optional string): Translation Unit unique identifier
-- `sentence_before` (optional string): Context sentence before
-- `sentence_after` (optional string): Context sentence after
-
-**Returns**: Removed translation details
-</details>
-
-<details>
-<summary><strong>import_tmx</strong> - Import a TMX file into a memory</summary>
-
-**Inputs**:
-- `id` (string): ID of the memory to update
-- `tmx_content` (string): The content of the tmx file to upload
-- `gzip` (boolean): Indicates if the file is compressed (.gz)
-
-**Returns**: Import details
-</details>
-
-<details>
-<summary><strong>check_import_status</strong> - Checks the status of a TMX file import</summary>
-
-**Inputs**:
-- `id` (string): The ID of the import job
-
-**Returns**: Import details
-</details>
-
-## 🚀 Getting Started
-Lara supports both the STDIO and streamable HTTP protocols. For a hassle-free setup, we recommend using the HTTP protocol. If you prefer to use STDIO, it must be installed locally on your machine.
-
-You'll find setup instructions for both protocols in the sections below.
-
-## ⚠️ Security Note
-
-**Important:** When running your own HTTP server instance (not using the remote `https://mcp.laratranslate.com/v1`), all connected clients share the same Lara API credentials configured via `LARA_ACCESS_KEY_ID` and `LARA_ACCESS_KEY_SECRET` environment variables.
-
-This server is designed for:
-- ✅ Single-user deployments
-- ✅ Trusted-environment deployments (e.g., internal tools)
-
-For multi-tenant scenarios, either:
-- Use the remote server at `https://mcp.laratranslate.com/v1` where each client provides their own credentials via headers
-- Deploy separate MCP server instances per user with isolated credentials
-
-### HTTP Server 🌐
-<details>
-<summary><strong>❌ Clients NOT supporting <code>url</code> configuration (e.g., Claude, OpenAI)</strong></summary>
-
-This installation guide is intended for clients that do NOT support the url-based configuration. This option requires Node.js to be installed on your system.
-
-> If you're unsure how to configure an MCP with your client, please refer to your MCP client's official documentation.
-
----
-
-1. Open your client's MCP configuration JSON file with a text editor, then copy and paste the following snippet:
+Open your config file (`~/.cursor/mcp.json` on macOS/Linux, `%APPDATA%\Cursor\mcp.json` on Windows) and paste:
 
 ```json
 {
   "mcpServers": {
-    "lara": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.laratranslate.com/v1",
-        "--header",
-        "x-lara-access-key-id: ${X_LARA_ACCESS_KEY_ID}",
-        "--header",
-        "x-lara-access-key-secret: ${X_LARA_ACCESS_KEY_SECRET}"
-      ],
-      "env": {
-        "X_LARA_ACCESS_KEY_ID": "<YOUR_ACCESS_KEY_ID>",
-        "X_LARA_ACCESS_KEY_SECRET": "<YOUR_ACCESS_KEY_SECRET>"
-      }
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
     }
   }
 }
 ```
 
-2. Replace `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your Lara Translate API credentials. Refer to the [Official Documentation](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials) for details.
+Save and restart Cursor. The first time you use a Lara tool, your browser will open to authenticate.
 
-3. Restart your MCP client.
+### Claude Code
 
-</details>
+Once Lara Translate is listed in the official Claude Code plugin marketplace, install it from inside Claude Code:
 
-<details>
-<summary><strong>✅ Clients supporting <code>url</code> configuration (e.g., Cursor, Continue)</strong></summary>
-
-This installation guide is intended for clients that support the url-based configuration. These clients can connect to Lara through a remote HTTP endpoint by specifying a simple configuration object.
-
-Some examples of supported clients include Cursor, Continue, OpenDevin, and Aider.
-> If you're unsure how to configure an MCP with your client, please refer to your MCP client's official documentation.
-
----
-
-1. Open your client's MCP configuration JSON file with a text editor, then copy and paste the following snippet:
-
-```json
-{
-  "mcpServers": {
-    "lara": {
-      "url": "https://mcp.laratranslate.com/v1",
-      "headers": {
-        "x-lara-access-key-id": "<YOUR_ACCESS_KEY_ID>",
-        "x-lara-access-key-secret": "<YOUR_ACCESS_KEY_SECRET>"
-      }
-    }
-  }
-}
+```
+/plugin
 ```
 
-2. Replace `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your Lara Translate API credentials. Refer to the [Official Documentation](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials) for details.
+Search for **Lara Translate** and install. The first time you use a Lara tool, your browser will open to authenticate.
 
-3. Restart your MCP client.
+In the meantime, or for manual installation, see the [Client Setup Guide](docs/client-setup.md#claude-code).
 
-</details>
+### Other Clients
+
+For step-by-step OAuth setup on **VS Code (GitHub Copilot)**, **Windsurf**, **Cline**, **Continue**, and more, see the **[Client Setup Guide](docs/client-setup.md)**.
+
+If your client isn't listed, the general approach is to add the server URL (`https://mcp-v2.laratranslate.com/v1`) to your MCP config — the client will handle OAuth authentication automatically.
+
+> For a complete list of MCP-compatible clients, visit the [official MCP clients page](https://modelcontextprotocol.io/clients).
+
+### Verify It Works
+
+After setup, test with a simple prompt:
+
+```
+Translate with Lara "Hello world" to Spanish
+```
+
+Your client should invoke Lara Translate and return the translation.
 
 ---
 
-### STDIO Server 🖥️
-<details>
-<summary><strong>Using NPX</strong></summary>
+## Available Tools
 
-This option requires Node.js to be installed on your system.
+### Translation
 
-1. Add the following to your MCP configuration file:
+| Tool | Description |
+|------|-------------|
+| `translate` | Translate text between languages with support for context, instructions, translation memories, glossaries, and multiple styles (faithful/fluid/creative) |
+
+### Language Detection
+
+| Tool | Description |
+|------|-------------|
+| `detect_language` | Detect the language of a given text or array of texts |
+| `list_languages` | List all supported language codes |
+
+### Translation Memories
+
+| Tool | Description |
+|------|-------------|
+| `list_memories` | List all translation memories in your account |
+| `create_memory` | Create a new translation memory |
+| `update_memory` | Update a translation memory's name |
+| `delete_memory` | Delete a translation memory |
+| `add_translation` | Add a translation unit (source + target pair) to a memory |
+| `delete_translation` | Delete a translation unit from a memory |
+| `import_tmx` | Import a TMX file into a memory |
+| `check_import_status` | Check the status of a TMX import job |
+
+### Glossaries
+
+| Tool | Description |
+|------|-------------|
+| `list_glossaries` | List all glossaries in your account |
+| `get_glossary` | Get details of a specific glossary |
+| `create_glossary` | Create a new glossary |
+| `update_glossary` | Update a glossary's name |
+| `delete_glossary` | Delete a glossary |
+| `add_glossary_entry` | Add or replace a term entry in a glossary |
+| `delete_glossary_entry` | Delete a term entry from a glossary |
+| `import_glossary_csv` | Import entries from a CSV file into a glossary |
+| `check_glossary_import_status` | Check the status of a glossary CSV import job |
+| `export_glossary` | Export a glossary as CSV |
+| `get_glossary_counts` | Get the number of entries in a glossary |
+
+---
+
+## Authentication
+
+### OAuth 2.0 (default)
+
+This is the method used in the [Quick Start](#quick-start) above. You provide only the server URL in your client config — no API keys needed. Your client handles the OAuth flow automatically: it opens your browser, you log in with your Lara Translate credentials, and you're connected.
+
+For per-client OAuth setup instructions, see the **[Client Setup Guide](docs/client-setup.md)**.
+
+### Access Key (alternative)
+
+If you prefer to authenticate with API keys instead of browser login, you can pass your credentials directly in the client config. Get your **Access Key ID** and **Secret** from [Lara Translate](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials).
+
+See the [Access Key section in the Client Setup Guide](docs/client-setup.md#alternative-access-key-authentication) for config examples.
+
+---
+
+## Self-Hosting
+
+Most users can connect to the hosted endpoint (`https://mcp-v2.laratranslate.com/v1`) using the [Quick Start](#quick-start) instructions above. The options below are for running the server yourself.
+
+### STDIO via NPX
+
+Requires [Node.js](https://nodejs.org/).
+
 ```json
 {
   "mcpServers": {
@@ -432,28 +156,19 @@ This option requires Node.js to be installed on your system.
 }
 ```
 
-2. Replace `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your actual Lara API credentials.
-</details>
+### STDIO via Docker
 
-<details>
-<summary><strong>Using Docker</strong></summary>
+Requires [Docker](https://www.docker.com/).
 
-This option requires Docker to be installed on your system.
-
-1. Add the following to your MCP configuration file:
 ```json
 {
   "mcpServers": {
     "lara-translate": {
       "command": "docker",
       "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "LARA_ACCESS_KEY_ID",
-        "-e",
-        "LARA_ACCESS_KEY_SECRET",
+        "run", "-i", "--rm",
+        "-e", "LARA_ACCESS_KEY_ID",
+        "-e", "LARA_ACCESS_KEY_SECRET",
         "translatednet/lara-mcp:latest"
       ],
       "env": {
@@ -465,36 +180,25 @@ This option requires Docker to be installed on your system.
 }
 ```
 
-2. Replace `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your actual Lara API credentials.
-</details>
+### Building from Source
 
-<details>
-<summary><strong>Building from Source</strong></summary>
+#### Node.js
 
-#### Using Node.js
-
-1. Clone the repository:
 ```bash
 git clone https://github.com/translated/lara-mcp.git
 cd lara-mcp
-```
-
-2. Install dependencies and build:
-```bash
-# Install dependencies
 pnpm install
-
-# Build
 pnpm run build
 ```
 
-3. Add the following to your MCP configuration file:
+Then add to your MCP config:
+
 ```json
 {
   "mcpServers": {
     "lara-translate": {
       "command": "node",
-      "args": ["<FULL_PATH_TO_PROJECT_FOLDER>/dist/index.js"],
+      "args": ["<FULL_PATH_TO_PROJECT>/dist/index.js"],
       "env": {
         "LARA_ACCESS_KEY_ID": "<YOUR_ACCESS_KEY_ID>",
         "LARA_ACCESS_KEY_SECRET": "<YOUR_ACCESS_KEY_SECRET>"
@@ -503,37 +207,26 @@ pnpm run build
   }
 }
 ```
-4. Replace:
-   - `<FULL_PATH_TO_PROJECT_FOLDER>` with the absolute path to your project folder
-   - `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your actual Lara API credentials.
 
-#### Building a Docker Image
+#### Docker
 
-1. Clone the repository:
 ```bash
 git clone https://github.com/translated/lara-mcp.git
 cd lara-mcp
-```
-
-2. Build the Docker image:
-```bash
 docker build -t lara-mcp .
 ```
 
-3. Add the following to your MCP configuration file:
+Then add to your MCP config:
+
 ```json
 {
   "mcpServers": {
     "lara-translate": {
       "command": "docker",
       "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "LARA_ACCESS_KEY_ID",
-        "-e",
-        "LARA_ACCESS_KEY_SECRET",
+        "run", "-i", "--rm",
+        "-e", "LARA_ACCESS_KEY_ID",
+        "-e", "LARA_ACCESS_KEY_SECRET",
         "lara-mcp"
       ],
       "env": {
@@ -545,35 +238,9 @@ docker build -t lara-mcp .
 }
 ```
 
-4. Replace `<YOUR_ACCESS_KEY_ID>` and `<YOUR_ACCESS_KEY_SECRET>` with your actual credentials.
-</details>
+---
 
-## 🧪 Verify Installation
+## Support
 
-After restarting your MCP client, you should see Lara Translate MCP in the list of available MCPs.
-> The method for viewing installed MCPs varies by client. Please consult your MCP client's documentation.
-
-To verify that Lara Translate MCP is working correctly, try translating with a simple prompt:
-```text
-Translate with Lara "Hello world" to Spanish
-```
-
-Your MCP client will begin generating a response. If Lara Translate MCP is properly installed and configured, your client will either request approval for the action or display a notification that Lara Translate is being used.
-
-## 💻 Popular Clients that supports MCPs 
-
-> For a complete list of MCP clients and their feature support, visit the [official MCP clients page](https://modelcontextprotocol.io/clients).
-
-| Client                                                            | Description                                          |
-|-------------------------------------------------------------------|------------------------------------------------------|
-| [Claude Desktop](https://claude.ai/download)                      | Desktop application for Claude AI                    |
-| [Aixplain](https://aixplain.com/)                                 | Production-ready AI Agents                           |
-| [Cursor](https://www.cursor.com/)                                 | AI-first code editor                                 |
-| [Cline for VS Code](https://github.com/cline/cline)               | VS Code extension for AI assistance                  |
-| [GitHub Copilot MCP](https://github.com/VikashLoomba/copilot-mcp) | VS Code extension for GitHub Copilot MCP integration |
-| [Windsurf](https://windsurf.com/editor)                           | AI-powered code editor and development environment   |
-
-## 🆘 Support
-
-- For issues with Lara Translate API: Visit [Lara Translate API and Integrations Support](https://support.laratranslate.com)
-- For issues with this MCP Server: Open an issue on [GitHub](https://github.com/translated/lara-mcp/issues)
+- For issues with Lara Translate API: visit [Lara Translate Support](https://support.laratranslate.com)
+- For issues with this MCP server: open an issue on [GitHub](https://github.com/translated/lara-mcp/issues)

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -23,9 +23,6 @@ Connect Lara Translate to your favorite AI client. The recommended method uses *
 3. Enter the name: `Lara`
 4. Enter the URL: `https://mcp-v2.laratranslate.com/v1`
 5. Click **Add**
-
-![Add Custom Connector](https://downloads.intercomcdn.com/i/o/lupk8zyo/1731190757/b6b02b1879bb55fb9ab32f222b06/8d09370d-1c7a-489c-b62b-b3484aaaef31?expires%3D1765471500%26signature%3D0d8212f6938008d55dec82fdc3e20b64c07b93ebec368ab74cba77e7980d099a%26req%3DdSckF8h3nYZaXvMW1HO4zYLxKhd694%2BiiJlgl7fGiwR%2F%2BSImZUUlz6Dw2QdV%0AKllJvjnsbArbYSudYjw%3D%0A)
-
 6. Click **Connect** next to the connector. Your browser will open the Lara Translate login page.
 7. Log in with your Lara Translate credentials. You'll be redirected back to Claude Desktop automatically.
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1,0 +1,281 @@
+# Client Setup Guide
+
+Connect Lara Translate to your favorite AI client. The recommended method uses **OAuth** — just enter the server URL and log in through your browser. No API keys to manage.
+
+## Table of Contents
+
+- [Claude Desktop](#claude-desktop)
+- [Cursor](#cursor)
+- [Claude Code](#claude-code)
+- [VS Code (GitHub Copilot)](#vs-code-github-copilot)
+- [Windsurf](#windsurf)
+- [Cline (VS Code)](#cline-vs-code)
+- [Continue](#continue)
+- [Alternative: Access Key Authentication](#alternative-access-key-authentication)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Claude Desktop
+
+1. Open Claude Desktop and go to **Settings** > **Connectors**
+2. Click **Add Custom Connector**
+3. Enter the name: `Lara`
+4. Enter the URL: `https://mcp-v2.laratranslate.com/v1`
+5. Click **Add**
+
+![Add Custom Connector](https://downloads.intercomcdn.com/i/o/lupk8zyo/1731190757/b6b02b1879bb55fb9ab32f222b06/8d09370d-1c7a-489c-b62b-b3484aaaef31?expires%3D1765471500%26signature%3D0d8212f6938008d55dec82fdc3e20b64c07b93ebec368ab74cba77e7980d099a%26req%3DdSckF8h3nYZaXvMW1HO4zYLxKhd694%2BiiJlgl7fGiwR%2F%2BSImZUUlz6Dw2QdV%0AKllJvjnsbArbYSudYjw%3D%0A)
+
+6. Click **Connect** next to the connector. Your browser will open the Lara Translate login page.
+7. Log in with your Lara Translate credentials. You'll be redirected back to Claude Desktop automatically.
+
+That's it — Lara Translate is now available in your conversations.
+
+> For more on custom connectors, see the [Claude documentation](https://support.claude.com/en/articles/11175166-getting-started-with-custom-connectors-using-remote-mcp).
+
+---
+
+## Cursor
+
+1. Open the MCP config file:
+   - **macOS**: `~/.cursor/mcp.json`
+   - **Windows**: `%APPDATA%\Cursor\mcp.json`
+   - **Linux**: `~/.cursor/mcp.json`
+
+2. Paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+3. Save and restart Cursor.
+4. The first time you use a Lara tool, Cursor will open your browser to authenticate with your Lara Translate credentials.
+
+---
+
+## Claude Code
+
+Run this command in your terminal:
+
+```bash
+claude mcp add lara-translate --transport http --url https://mcp-v2.laratranslate.com/v1
+```
+
+The first time Lara tools are used, Claude Code will open your browser to authenticate with your Lara Translate credentials.
+
+Alternatively, create a `.mcp.json` file in your project root:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "type": "http",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+---
+
+## VS Code (GitHub Copilot)
+
+VS Code supports MCP servers through GitHub Copilot's agent mode.
+
+### Option A: Project-level config
+
+Create a `.vscode/mcp.json` file in your project:
+
+```json
+{
+  "servers": {
+    "lara-translate": {
+      "type": "http",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+### Option B: User settings
+
+Open VS Code Settings (JSON) and add:
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "lara-translate": {
+        "type": "http",
+        "url": "https://mcp-v2.laratranslate.com/v1"
+      }
+    }
+  }
+}
+```
+
+Save and reload VS Code. When you first use a Lara tool in Copilot's agent mode, your browser will open to authenticate with Lara Translate.
+
+> MCP support in VS Code requires GitHub Copilot. See the [VS Code MCP documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) for details.
+
+---
+
+## Windsurf
+
+1. Open the config file:
+   - **macOS / Linux**: `~/.codeium/windsurf/mcp_config.json`
+   - **Windows**: `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
+
+   Or in Windsurf: **Settings** > search "MCP" > **Edit in mcp_config.json**.
+
+2. Paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "serverUrl": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+3. Save and restart Windsurf. Your browser will open to authenticate the first time you use a Lara tool.
+
+---
+
+## Cline (VS Code)
+
+1. Open VS Code and click the **Cline** icon in the sidebar.
+2. Click the **MCP Servers** button (server icon) at the top of the Cline panel.
+3. Click **Remote Servers**.
+4. Add:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}
+```
+
+5. Save. Your browser will open to authenticate when you first use a Lara tool.
+
+---
+
+## Continue
+
+1. Open the config file:
+   - **macOS / Linux**: `~/.continue/config.json`
+   - **Windows**: `%USERPROFILE%\.continue\config.json`
+
+   Or use the Continue sidebar > gear icon.
+
+2. Add the `mcpServers` section:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "lara-translate",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  ]
+}
+```
+
+3. Save and restart Continue. Your browser will open to authenticate when you first use a Lara tool.
+
+> Note: Continue uses an array format for `mcpServers`. See the [Continue MCP docs](https://docs.continue.dev/customize/model-context-protocol) for details.
+
+---
+
+## Alternative: Access Key Authentication
+
+If your client doesn't support OAuth, or you prefer to authenticate with API keys instead of browser login, you can pass your credentials directly in the config. Get your **Access Key ID** and **Secret** from [Lara Translate](https://developers.laratranslate.com/docs/getting-started#step-3---configure-your-credentials).
+
+### Clients with `url` support (Cursor, Windsurf, VS Code, Cline, Continue, Claude Code)
+
+Add your credentials as headers alongside the URL:
+
+```json
+{
+  "lara-translate": {
+    "url": "https://mcp-v2.laratranslate.com/v1",
+    "headers": {
+      "x-lara-access-key-id": "<YOUR_ACCESS_KEY_ID>",
+      "x-lara-access-key-secret": "<YOUR_ACCESS_KEY_SECRET>"
+    }
+  }
+}
+```
+
+> Adapt the wrapper format to your client (e.g., `"mcpServers"` for Cursor, `"servers"` with `"type": "http"` for VS Code, etc.). See the OAuth sections above for each client's exact format.
+
+### Claude Desktop (command-based)
+
+Claude Desktop doesn't support `url`-based configs directly, so it uses `mcp-remote` as a bridge. Requires [Node.js](https://nodejs.org/).
+
+Open the config file:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Paste:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp-v2.laratranslate.com/v1",
+        "--header",
+        "x-lara-access-key-id: ${X_LARA_ACCESS_KEY_ID}",
+        "--header",
+        "x-lara-access-key-secret: ${X_LARA_ACCESS_KEY_SECRET}"
+      ],
+      "env": {
+        "X_LARA_ACCESS_KEY_ID": "<YOUR_ACCESS_KEY_ID>",
+        "X_LARA_ACCESS_KEY_SECRET": "<YOUR_ACCESS_KEY_SECRET>"
+      }
+    }
+  }
+}
+```
+
+Replace the placeholders with your credentials, save, and restart Claude Desktop.
+
+---
+
+## Troubleshooting
+
+**OAuth login page doesn't open?**
+- Ensure your client supports OAuth for MCP servers (check your client's documentation)
+- Make sure your default browser is set and can open URLs
+- Try the [Access Key method](#alternative-access-key-authentication) as a fallback
+
+**Server not showing up after restart?**
+- Double-check your JSON syntax (missing commas, trailing commas, etc.)
+- Ensure the config file is in the correct location for your OS
+- Some clients require a full application restart, not just a window reload
+
+**Authentication errors?**
+- If using Access Key: verify your credentials are correct and active in your [Lara Translate account](https://laratranslate.com)
+- If using OAuth: try disconnecting and reconnecting to re-authenticate
+
+**Connection issues with `mcp-remote`?**
+- Ensure [Node.js](https://nodejs.org/) (v18+) is installed: `node --version`
+- Check your network/firewall allows outbound HTTPS connections
+
+**Still stuck?**
+- For API issues: [Lara Translate Support](https://support.laratranslate.com)
+- For MCP server issues: [GitHub Issues](https://github.com/translated/lara-mcp/issues)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translated/lara-mcp",
-  "version": "0.0.17",
+  "version": "1.0.0",
   "description": "Lara API official MCP server",
   "author": {
     "name": "Translated",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "lara-translate",
+  "version": "1.0.0",
+  "description": "AI-powered translation via Lara Translate — connects Claude Code to translation memories, glossaries, and 200+ language pairs.",
+  "author": {
+    "name": "Translated",
+    "email": "support@laratranslate.com",
+    "url": "https://translated.com"
+  },
+  "homepage": "https://laratranslate.com",
+  "repository": "https://github.com/translated/lara-mcp",
+  "license": "MIT",
+  "keywords": ["translation", "localization", "i18n", "lara", "mcp"]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lara": {
+      "type": "http",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}

--- a/plugin/LICENSE
+++ b/plugin/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2025 Translated, Srl. (https://translated.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,26 @@
+# Lara Translate — Claude Code plugin
+
+Official Claude Code plugin for [Lara Translate](https://laratranslate.com). Gives Claude access to Lara's translation engine, translation memories, and glossaries via the hosted MCP endpoint at `https://mcp-v2.laratranslate.com/v1`.
+
+## Install
+
+From inside Claude Code, open the plugin browser:
+
+```
+/plugin
+```
+
+Search for **Lara Translate** and install. The first tool call triggers a browser-based OAuth login against Lara. No API keys or local processes required.
+
+## Usage
+
+Ask Claude to translate something, extend a translation memory, or look up a glossary term. Available tools include translation, language detection, translation memory management, and glossary operations — Claude selects the right one based on your request.
+
+## Advanced setup
+
+For self-hosted or API-key-based setups (stdio transport, Docker, custom OAuth), see the full documentation in [`docs/client-setup.md`](https://github.com/translated/lara-mcp/blob/main/docs/client-setup.md).
+
+## Support
+
+- Issues: https://github.com/translated/lara-mcp/issues
+- Email: support@laratranslate.com

--- a/src/__tests__/tools/annotations.test.ts
+++ b/src/__tests__/tools/annotations.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+// Stub the logger before importing `mcp/tools.js`: the real logger pulls in
+// `src/env.ts`, which strictly parses `PUBLIC_HOST` at module load.
+vi.mock("#logger", () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { ListTools } from "../../mcp/tools.js";
+
+// Anthropic Software Directory policy requires every tool to advertise
+// title, readOnlyHint, and destructiveHint annotations, plus a name within
+// the 64-char MCP limit, so clients can render labels and warn before
+// destructive calls.
+// https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy
+describe("Tool annotations", () => {
+  it("declares title, readOnlyHint, and destructiveHint on every tool, with a name within the 64-char limit", async () => {
+    const { tools } = await ListTools();
+
+    expect(tools.length).toBeGreaterThan(0);
+
+    for (const tool of tools as Tool[]) {
+      expect(
+        tool.name.length,
+        `tool name "${tool.name}" exceeds the 64-char MCP limit`
+      ).toBeLessThanOrEqual(64);
+
+      const ann = tool.annotations;
+      expect(ann, `tool "${tool.name}" is missing annotations`).toBeDefined();
+      expect(ann!.title, `tool "${tool.name}" annotations.title`).toBeTypeOf("string");
+      expect(ann!.title!.length).toBeGreaterThan(0);
+      expect(ann!.readOnlyHint, `tool "${tool.name}" annotations.readOnlyHint`).toBeTypeOf("boolean");
+      expect(ann!.destructiveHint, `tool "${tool.name}" annotations.destructiveHint`).toBeTypeOf("boolean");
+    }
+  });
+});

--- a/src/__tests__/tools/annotations.test.ts
+++ b/src/__tests__/tools/annotations.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 // Stub the logger before importing `mcp/tools.js`: the real logger pulls in
-// `src/env.ts`, which strictly parses `PUBLIC_HOST` at module load.
+// `src/env.ts`, which parses `process.env` at module load — side effects
+// we don't need for this pure shape-of-ListTools() assertion.
 vi.mock("#logger", () => ({
   logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -205,7 +205,7 @@ const toolDefinitions = [
   {
     name: "delete_translation",
     description:
-      "Deletes a translation from a translation memory from your Lara Translate account.",
+      "Deletes a translation from a translation memory in your Lara Translate account.",
     inputSchema: z.toJSONSchema(deleteTranslationSchema),
     annotations: {
       title: "Delete translation unit from memory",

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -130,144 +130,258 @@ async function CallTool(
   }
 }
 
+// Anthropic Software Directory policy requires every tool to advertise title,
+// readOnlyHint, and destructiveHint so clients can render labels and warn
+// before destructive calls.
+// https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy
+const toolDefinitions = [
+  {
+    name: "detect_language",
+    description:
+      "Detects the language of the provided text. Returns the detected language, content type, and a list of predictions with confidence scores. Accepts a single string or an array of strings (up to 128 elements).",
+    inputSchema: z.toJSONSchema(detectLanguageSchema),
+    annotations: {
+      title: "Detect language",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "translate",
+    description:
+      "Translate text between languages using Lara Translate. Supports language detection, context-aware translations, translation memories, and glossaries. " +
+      "The optional 'instructions' parameter accepts short localization directives (e.g., 'Translate formally') — only provide them when the content specifically requires tone, formality, or terminology adjustments.",
+    inputSchema: z.toJSONSchema(translateSchema),
+    annotations: {
+      title: "Translate text",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "create_memory",
+    description:
+      "Create a translation memory with a custom name in your Lara Translate account. Translation memories store pairs of source and target text segments (translation units) for reuse in future translations.",
+    inputSchema: z.toJSONSchema(createMemorySchema),
+    annotations: {
+      title: "Create translation memory",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "delete_memory",
+    description:
+      "Deletes a translation memory from your Lara Translate account.",
+    inputSchema: z.toJSONSchema(deleteMemorySchema),
+    annotations: {
+      title: "Delete translation memory",
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "update_memory",
+    description:
+      "Updates a translation memory in your Lara Translate account.",
+    inputSchema: z.toJSONSchema(updateMemorySchema),
+    annotations: {
+      title: "Rename translation memory",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "add_translation",
+    description:
+      "Adds a translation to a translation memory in your Lara Translate account.",
+    inputSchema: z.toJSONSchema(addTranslationSchema),
+    annotations: {
+      title: "Add translation unit to memory",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "delete_translation",
+    description:
+      "Deletes a translation from a translation memory from your Lara Translate account.",
+    inputSchema: z.toJSONSchema(deleteTranslationSchema),
+    annotations: {
+      title: "Delete translation unit from memory",
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "import_tmx",
+    description:
+      "Imports a TMX file into a translation memory. This is an async operation that returns an import job object containing an import_id. Poll with check_import_status using the returned import_id until the import is complete.",
+    inputSchema: z.toJSONSchema(importTmxSchema),
+    annotations: {
+      title: "Import TMX file",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "check_import_status",
+    description:
+      "Checks the status of a TMX import job started by import_tmx. Poll this tool with the import_id returned from import_tmx until the import is complete. The response includes a progress field to track completion.",
+    inputSchema: z.toJSONSchema(checkImportStatusSchema),
+    annotations: {
+      title: "Check TMX import status",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "list_memories",
+    description:
+      "Lists all translation memories in your Lara Translate account.",
+    inputSchema: z.toJSONSchema(listMemoriesSchema),
+    annotations: {
+      title: "List translation memories",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "list_languages",
+    description:
+      "Lists all supported languages in your Lara Translate account.",
+    inputSchema: z.toJSONSchema(listLanguagesSchema),
+    annotations: {
+      title: "List supported languages",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "list_glossaries",
+    description:
+      "Lists all glossaries in your Lara Translate account. Glossaries are collections of terms with their translations that enforce specific terminology during translation.",
+    inputSchema: z.toJSONSchema(listGlossariesSchema),
+    annotations: {
+      title: "List glossaries",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "get_glossary",
+    description:
+      "Retrieves a specific glossary by ID from your Lara Translate account. Returns null if the glossary is not found.",
+    inputSchema: z.toJSONSchema(getGlossarySchema),
+    annotations: {
+      title: "Get glossary",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "create_glossary",
+    description:
+      "Create a glossary with a custom name in your Lara Translate account. Glossaries enforce specific terminology during translation.",
+    inputSchema: z.toJSONSchema(createGlossarySchema),
+    annotations: {
+      title: "Create glossary",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "update_glossary",
+    description:
+      "Updates the name of a glossary in your Lara Translate account.",
+    inputSchema: z.toJSONSchema(updateGlossarySchema),
+    annotations: {
+      title: "Rename glossary",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "delete_glossary",
+    description:
+      "Deletes a glossary from your Lara Translate account.",
+    inputSchema: z.toJSONSchema(deleteGlossarySchema),
+    annotations: {
+      title: "Delete glossary",
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
+  },
+  {
+    name: "import_glossary_csv",
+    description:
+      "Imports a CSV file into a glossary. Supports unidirectional and multidirectional formats. This is an async operation that returns an import job object containing an import_id. Poll with check_glossary_import_status using the returned import_id until the import is complete.",
+    inputSchema: z.toJSONSchema(importGlossaryCsvSchema),
+    annotations: {
+      title: "Import glossary CSV",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "check_glossary_import_status",
+    description:
+      "Checks the status of a glossary CSV import job started by import_glossary_csv. Poll this tool with the import_id returned from import_glossary_csv until the import is complete.",
+    inputSchema: z.toJSONSchema(checkGlossaryImportStatusSchema),
+    annotations: {
+      title: "Check glossary import status",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "export_glossary",
+    description:
+      "Exports a glossary as CSV from your Lara Translate account. Supports unidirectional and multidirectional formats.",
+    inputSchema: z.toJSONSchema(exportGlossarySchema),
+    annotations: {
+      title: "Export glossary as CSV",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "get_glossary_counts",
+    description:
+      "Retrieves the term and language counts for a glossary in your Lara Translate account.",
+    inputSchema: z.toJSONSchema(getGlossaryCountsSchema),
+    annotations: {
+      title: "Get glossary entry count",
+      readOnlyHint: true,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "add_glossary_entry",
+    description:
+      "Adds or replaces an entry in a glossary in your Lara Translate account. Supports both monodirectional and multidirectional glossaries.",
+    inputSchema: z.toJSONSchema(addGlossaryEntrySchema),
+    annotations: {
+      title: "Add or replace glossary entry",
+      readOnlyHint: false,
+      destructiveHint: false,
+    },
+  },
+  {
+    name: "delete_glossary_entry",
+    description:
+      "Deletes an entry from a glossary in your Lara Translate account. Use term for monodirectional glossaries or guid for multidirectional glossaries.",
+    inputSchema: z.toJSONSchema(deleteGlossaryEntrySchema),
+    annotations: {
+      title: "Delete glossary entry",
+      readOnlyHint: false,
+      destructiveHint: true,
+    },
+  },
+];
+
 async function ListTools() {
-  return {
-    tools: [
-      {
-        name: "detect_language",
-        description:
-          "Detects the language of the provided text. Returns the detected language, content type, and a list of predictions with confidence scores. Accepts a single string or an array of strings (up to 128 elements).",
-        inputSchema: z.toJSONSchema(detectLanguageSchema),
-      },
-      {
-        name: "translate",
-        description:
-          "Translate text between languages using Lara Translate. Supports language detection, context-aware translations, translation memories, and glossaries. " +
-          "The optional 'instructions' parameter accepts short localization directives (e.g., 'Translate formally') — only provide them when the content specifically requires tone, formality, or terminology adjustments.",
-        inputSchema: z.toJSONSchema(translateSchema),
-      },
-      {
-        name: "create_memory",
-        description:
-          "Create a translation memory with a custom name in your Lara Translate account. Translation memories store pairs of source and target text segments (translation units) for reuse in future translations.",
-        inputSchema: z.toJSONSchema(createMemorySchema),
-      },
-      {
-        name: "delete_memory",
-        description:
-          "Deletes a translation memory from your Lara Translate account.",
-        inputSchema: z.toJSONSchema(deleteMemorySchema),
-      },
-      {
-        name: "update_memory",
-        description:
-          "Updates a translation memory in your Lara Translate account.",
-        inputSchema: z.toJSONSchema(updateMemorySchema),
-      },
-      {
-        name: "add_translation",
-        description:
-          "Adds a translation to a translation memory in your Lara Translate account.",
-        inputSchema: z.toJSONSchema(addTranslationSchema),
-      },
-      {
-        name: "delete_translation",
-        description:
-          "Deletes a translation from a translation memory from your Lara Translate account.",
-        inputSchema: z.toJSONSchema(deleteTranslationSchema),
-      },
-      {
-        name: "import_tmx",
-        description:
-          "Imports a TMX file into a translation memory. This is an async operation that returns an import job object containing an import_id. Poll with check_import_status using the returned import_id until the import is complete.",
-        inputSchema: z.toJSONSchema(importTmxSchema),
-      },
-      {
-        name: "check_import_status",
-        description:
-          "Checks the status of a TMX import job started by import_tmx. Poll this tool with the import_id returned from import_tmx until the import is complete. The response includes a progress field to track completion.",
-        inputSchema: z.toJSONSchema(checkImportStatusSchema),
-      },
-      {
-        name: "list_memories",
-        description:
-          "Lists all translation memories in your Lara Translate account.",
-        inputSchema: z.toJSONSchema(listMemoriesSchema),
-      },
-      {
-        name: "list_languages",
-        description:
-          "Lists all supported languages in your Lara Translate account.",
-        inputSchema: z.toJSONSchema(listLanguagesSchema),
-      },
-      {
-        name: "list_glossaries",
-        description:
-          "Lists all glossaries in your Lara Translate account. Glossaries are collections of terms with their translations that enforce specific terminology during translation.",
-        inputSchema: z.toJSONSchema(listGlossariesSchema),
-      },
-      {
-        name: "get_glossary",
-        description:
-          "Retrieves a specific glossary by ID from your Lara Translate account. Returns null if the glossary is not found.",
-        inputSchema: z.toJSONSchema(getGlossarySchema),
-      },
-      {
-        name: "create_glossary",
-        description:
-          "Create a glossary with a custom name in your Lara Translate account. Glossaries enforce specific terminology during translation.",
-        inputSchema: z.toJSONSchema(createGlossarySchema),
-      },
-      {
-        name: "update_glossary",
-        description:
-          "Updates the name of a glossary in your Lara Translate account.",
-        inputSchema: z.toJSONSchema(updateGlossarySchema),
-      },
-      {
-        name: "delete_glossary",
-        description:
-          "Deletes a glossary from your Lara Translate account.",
-        inputSchema: z.toJSONSchema(deleteGlossarySchema),
-      },
-      {
-        name: "import_glossary_csv",
-        description:
-          "Imports a CSV file into a glossary. Supports unidirectional and multidirectional formats. This is an async operation that returns an import job object containing an import_id. Poll with check_glossary_import_status using the returned import_id until the import is complete.",
-        inputSchema: z.toJSONSchema(importGlossaryCsvSchema),
-      },
-      {
-        name: "check_glossary_import_status",
-        description:
-          "Checks the status of a glossary CSV import job started by import_glossary_csv. Poll this tool with the import_id returned from import_glossary_csv until the import is complete.",
-        inputSchema: z.toJSONSchema(checkGlossaryImportStatusSchema),
-      },
-      {
-        name: "export_glossary",
-        description:
-          "Exports a glossary as CSV from your Lara Translate account. Supports unidirectional and multidirectional formats.",
-        inputSchema: z.toJSONSchema(exportGlossarySchema),
-      },
-      {
-        name: "get_glossary_counts",
-        description:
-          "Retrieves the term and language counts for a glossary in your Lara Translate account.",
-        inputSchema: z.toJSONSchema(getGlossaryCountsSchema),
-      },
-      {
-        name: "add_glossary_entry",
-        description:
-          "Adds or replaces an entry in a glossary in your Lara Translate account. Supports both monodirectional and multidirectional glossaries.",
-        inputSchema: z.toJSONSchema(addGlossaryEntrySchema),
-      },
-      {
-        name: "delete_glossary_entry",
-        description:
-          "Deletes an entry from a glossary in your Lara Translate account. Use term for monodirectional glossaries or guid for multidirectional glossaries.",
-        inputSchema: z.toJSONSchema(deleteGlossaryEntrySchema),
-      },
-    ],
-  };
+  return { tools: toolDefinitions };
 }
 
 export { CallTool, ListTools };


### PR DESCRIPTION
## Summary

- **Tool annotations**: every MCP tool now advertises `title`, `readOnlyHint`, and `destructiveHint`
- **Endpoint rename**: `mcp.laratranslate.com/v1` → `mcp-v2.laratranslate.com/v1` across all user-facing docs.
- **Documentation rewrite**
- **Claude Code plugin**