### PR TITLE
feat: add Cursor plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,13 @@ Done — Lara Translate is now available in your conversations.
 
 ### Cursor
 
-Open your config file (`~/.cursor/mcp.json` on macOS/Linux, `%APPDATA%\Cursor\mcp.json` on Windows) and paste:
+Once Lara Translate is listed in the official Cursor plugin marketplace, install it from inside Cursor:
 
-```json
-{
-  "mcpServers": {
-    "lara-translate": {
-      "url": "https://mcp-v2.laratranslate.com/v1"
-    }
-  }
-}
-```
+1. Open the plugin browser and search for **Lara Translate**.
+2. Click **Install**.
+3. The first time you use a Lara tool, your browser will open to authenticate.
 
-Save and restart Cursor. The first time you use a Lara tool, your browser will open to authenticate.
+In the meantime, or for manual installation, see the [Client Setup Guide](docs/client-setup.md#cursor).
 
 ### Claude Code
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -34,6 +34,10 @@ That's it — Lara Translate is now available in your conversations.
 
 ## Cursor
 
+The recommended install is via the Cursor plugin marketplace: open the plugin browser, search for **Lara Translate**, and click **Install**. The first tool call opens your browser to authenticate.
+
+Alternatively, configure the MCP server manually:
+
 1. Open the MCP config file:
    - **macOS**: `~/.cursor/mcp.json`
    - **Windows**: `%APPDATA%\Cursor\mcp.json`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translated/lara-mcp",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "description": "Lara API official MCP server",
   "author": {
     "name": "Translated",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translated/lara-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lara API official MCP server",
   "author": {
     "name": "Translated",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lara-translate",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "description": "AI-powered translation via Lara Translate — connects Claude Code to translation memories, glossaries, and 200+ language pairs.",
   "author": {
     "name": "Translated",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lara-translate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AI-powered translation via Lara Translate — connects Claude Code to translation memories, glossaries, and 200+ language pairs.",
   "author": {
     "name": "Translated",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lara-translate",
   "description": "AI-powered translation via Lara Translate — connects Cursor to translation memories, glossaries, and 200+ language pairs.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Translated",
     "email": "support@laratranslate.com",

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "lara-translate",
+  "description": "AI-powered translation via Lara Translate — connects Cursor to translation memories, glossaries, and 200+ language pairs.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Translated",
+    "email": "support@laratranslate.com",
+    "url": "https://translated.com"
+  },
+  "homepage": "https://laratranslate.com",
+  "repository": "https://github.com/translated/lara-mcp",
+  "license": "MIT",
+  "keywords": [
+    "translation",
+    "localization",
+    "i18n",
+    "lara",
+    "mcp"
+  ]
+}

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lara-translate",
   "description": "AI-powered translation via Lara Translate — connects Cursor to translation memories, glossaries, and 200+ language pairs.",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "author": {
     "name": "Translated",
     "email": "support@laratranslate.com",

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "lara": {
+    "lara-translate": {
       "type": "http",
       "url": "https://mcp-v2.laratranslate.com/v1"
     }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,8 +1,10 @@
-# Lara Translate — Claude Code plugin
+# Lara Translate — plugin
 
-Official Claude Code plugin for [Lara Translate](https://laratranslate.com). Gives Claude access to Lara's translation engine, translation memories, and glossaries via the hosted MCP endpoint at `https://mcp-v2.laratranslate.com/v1`.
+Official plugin for [Lara Translate](https://laratranslate.com), compatible with both **Claude Code** and **Cursor**. Gives your AI assistant access to Lara's translation engine, translation memories, and glossaries via the hosted MCP endpoint at `https://mcp-v2.laratranslate.com/v1`.
 
 ## Install
+
+### Claude Code
 
 From inside Claude Code, open the plugin browser:
 
@@ -10,11 +12,19 @@ From inside Claude Code, open the plugin browser:
 /plugin
 ```
 
-Search for **Lara Translate** and install. The first tool call triggers a browser-based OAuth login against Lara. No API keys or local processes required.
+Search for **Lara Translate** and install.
+
+### Cursor
+
+From inside Cursor, open the plugin browser and search for **Lara Translate**, or install directly from this repository folder.
+
+---
+
+The first tool call in either client triggers a browser-based OAuth login against Lara. No API keys or local processes required.
 
 ## Usage
 
-Ask Claude to translate something, extend a translation memory, or look up a glossary term. Available tools include translation, language detection, translation memory management, and glossary operations — Claude selects the right one based on your request.
+Ask your assistant to translate something, extend a translation memory, or look up a glossary term. Available tools include translation, language detection, translation memory management, and glossary operations — the assistant selects the right one based on your request.
 
 ## Advanced setup
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -16,7 +16,7 @@ Search for **Lara Translate** and install.
 
 ### Cursor
 
-From inside Cursor, open the plugin browser and search for **Lara Translate**, or install directly from this repository folder.
+From inside Cursor, open the plugin browser and search for **Lara Translate**.
 
 ---
 

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "lara-translate": {
-      "type": "http",
-      "url": "https://mcp-v2.laratranslate.com/v1"
-    }
-  }
-}

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "lara": {
+    "lara-translate": {
       "type": "http",
       "url": "https://mcp-v2.laratranslate.com/v1"
     }

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lara": {
+      "type": "http",
+      "url": "https://mcp-v2.laratranslate.com/v1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Extends the existing `plugin/` package so it works as both a Claude Code plugin and a Cursor plugin from a single folder
- Adds `plugin/.cursor-plugin/plugin.json` manifest and `plugin/mcp.json` (mirrors `.mcp.json` for Cursor's default MCP discovery)
- Updates `plugin/README.md` to document install flows for both clients
