### PR TITLE
feat: align tool response shape with MCP spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,6 @@ Custom exception classes (`src/exception.ts`):
 - `ServerException` - Base exception with error code
 - `InvalidInputError` - Invalid request parameters (code: -32600)
 - `InvalidCredentialsError` - Authentication failure (code: -32600)
-- `MethodNotAllowedError` - HTTP method not allowed (code: -32601)
 
 Error handling in `src/mcp/tools.ts`:
 - Zod validation errors return specific field names (not full error details for security)

--- a/src/__tests__/server/rest.server.test.ts
+++ b/src/__tests__/server/rest.server.test.ts
@@ -84,21 +84,19 @@ describe("RestServer", () => {
     expect(res.status).toBe(200);
   });
 
-  it("GET /v1 should return MethodNotAllowedError", async () => {
+  it("GET /v1 should return 405 with Allow header and empty body", async () => {
     const res = await request(app).get("/v1").set(defaultHeaders);
 
-    expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("error");
-    expect(res.body.error).toHaveProperty("code");
-    expect(res.body.error).toHaveProperty("message");
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe("POST");
+    expect(res.text).toBe("");
   });
 
-    it("DELETE /v1 should return MethodNotAllowedError", async () => {
+  it("DELETE /v1 should return 405 with Allow header and empty body", async () => {
     const res = await request(app).delete("/v1").set(defaultHeaders);
 
-    expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("error");
-    expect(res.body.error).toHaveProperty("code");
-    expect(res.body.error).toHaveProperty("message");
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe("POST");
+    expect(res.text).toBe("");
   });
 });

--- a/src/__tests__/tools/annotations.test.ts
+++ b/src/__tests__/tools/annotations.test.ts
@@ -33,6 +33,7 @@ describe("Tool annotations", () => {
       expect(ann!.title!.length).toBeGreaterThan(0);
       expect(ann!.readOnlyHint, `tool "${tool.name}" annotations.readOnlyHint`).toBeTypeOf("boolean");
       expect(ann!.destructiveHint, `tool "${tool.name}" annotations.destructiveHint`).toBeTypeOf("boolean");
+      expect(ann!.openWorldHint, `tool "${tool.name}" annotations.openWorldHint`).toBeTypeOf("boolean");
     }
   });
 });

--- a/src/__tests__/tools/call_tool.test.ts
+++ b/src/__tests__/tools/call_tool.test.ts
@@ -92,6 +92,45 @@ describe('CallTool error handling', () => {
     await expect(promise).rejects.toThrow('Custom validation error from handler');
   });
 
+  it('should return structuredContent and narration for handler tools', async () => {
+    mockTranslator.translate.mockResolvedValue({
+      translation: 'Ciao',
+      sourceLanguage: 'en-US',
+    });
+
+    const request = makeRequest('translate', {
+      text: [{ text: 'Hello', translatable: true }],
+      target: 'it-IT',
+    });
+
+    const result = await CallTool(request, mockTranslator as any as Translator);
+
+    expect(result).toHaveProperty('structuredContent');
+    expect(result.structuredContent).toEqual({ value: 'Ciao' });
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content![0]).toHaveProperty('type', 'text');
+    expect((result.content![0] as any).text).toContain('it-IT');
+  });
+
+  it('should wrap array results under items in structuredContent for lister tools', async () => {
+    mockTranslator.memories.list.mockResolvedValue([
+      { id: 'mem_1', name: 'First' },
+      { id: 'mem_2', name: 'Second' },
+    ]);
+
+    const request = makeRequest('list_memories', {});
+
+    const result = await CallTool(request, mockTranslator as any as Translator);
+
+    expect(result.structuredContent).toEqual({
+      items: [
+        { id: 'mem_1', name: 'First' },
+        { id: 'mem_2', name: 'Second' },
+      ],
+    });
+    expect((result.content![0] as any).text).toContain('2');
+  });
+
   it('should return generic message for unknown errors', async () => {
     mockTranslator.memories.delete.mockRejectedValue(new TypeError('Something unexpected'));
 

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -14,14 +14,6 @@ class InvalidSessionIdError extends ServerException {
   }
 }
 
-class MethodNotAllowedError extends ServerException {
-  code: number = -32600;
-
-  constructor() {
-    super("Method not allowed");
-  }
-}
-
 class InvalidCredentialsError extends ServerException {
   code: number = -32600;
 
@@ -41,7 +33,6 @@ class InvalidInputError extends ServerException {
 export {
   ServerException,
   InvalidSessionIdError,
-  MethodNotAllowedError,
   InvalidCredentialsError,
   InvalidInputError,
 };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -73,6 +73,74 @@ const listers: Record<string, Lister> = {
   list_glossaries: listGlossaries,
 };
 
+function toStructuredContent(result: unknown): Record<string, unknown> {
+  if (Array.isArray(result)) return { items: result };
+  if (result !== null && typeof result === "object") return result as Record<string, unknown>;
+  return { value: result };
+}
+
+function invocationMeta(invoking: string, invoked: string) {
+  return {
+    "openai/toolInvocation/invoking": invoking,
+    "openai/toolInvocation/invoked": invoked,
+  };
+}
+
+function narrate(name: string, args: any, result: any): string {
+  switch (name) {
+    case "translate":
+      return Array.isArray(result)
+        ? `Translated ${result.length} segments${args?.target ? " to " + args.target : ""}`
+        : `Translated text${args?.target ? " to " + args.target : ""}`;
+    case "detect_language":
+      return Array.isArray(result)
+        ? `Detected language for ${result.length} inputs`
+        : `Detected language: ${result?.language ?? "unknown"}`;
+    case "list_languages":
+      return `Retrieved ${Array.isArray(result) ? result.length : 0} supported languages`;
+    case "list_memories":
+      return `Found ${Array.isArray(result) ? result.length : 0} translation memories`;
+    case "create_memory":
+      return `Created translation memory "${result?.name ?? args?.name ?? ""}"`;
+    case "update_memory":
+      return `Renamed translation memory to "${result?.name ?? args?.name ?? ""}"`;
+    case "delete_memory":
+      return `Deleted translation memory ${result?.id ?? args?.id ?? ""}`;
+    case "add_translation":
+      return "Added translation unit to memory";
+    case "delete_translation":
+      return "Deleted translation unit from memory";
+    case "import_tmx":
+      return `Queued TMX import${result?.id ? " (job " + result.id + ")" : ""}`;
+    case "check_import_status":
+      return `TMX import status: ${result?.status ?? "unknown"}`;
+    case "list_glossaries":
+      return `Found ${Array.isArray(result) ? result.length : 0} glossaries`;
+    case "get_glossary":
+      return `Retrieved glossary "${result?.name ?? args?.id ?? ""}"`;
+    case "create_glossary":
+      return `Created glossary "${result?.name ?? args?.name ?? ""}"`;
+    case "update_glossary":
+      return `Renamed glossary to "${result?.name ?? args?.name ?? ""}"`;
+    case "delete_glossary":
+      return `Deleted glossary ${result?.id ?? args?.id ?? ""}`;
+    case "add_glossary_entry":
+      return "Added entry to glossary";
+    case "delete_glossary_entry":
+      return "Deleted entry from glossary";
+    case "import_glossary_csv":
+      return `Queued glossary CSV import${result?.id ? " (job " + result.id + ")" : ""}`;
+    case "check_glossary_import_status":
+      return `Glossary import status: ${result?.status ?? "unknown"}`;
+    case "export_glossary":
+      return "Exported glossary as CSV";
+    case "get_glossary_counts":
+      return `Glossary entry count: ${result?.unidirectional ?? result?.multidirectional ?? "retrieved"}`;
+    default:
+      return `${name} completed`;
+  }
+}
+
 async function CallTool(
   request: CallToolRequest,
   lara: Translator
@@ -82,22 +150,20 @@ async function CallTool(
   logger.debug({ toolName: name }, "Tool called");
 
   try {
+    let result: unknown;
     if (name in handlers) {
-      const result = await handlers[name as keyof typeof handlers](args, lara);
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-      };
+      result = await handlers[name as keyof typeof handlers](args, lara);
+    } else if (name in listers) {
+      result = await listers[name as keyof typeof listers](lara);
+    } else {
+      logger.warn(`Requested a tool with name ${name}, but it was not found`);
+      throw new InvalidInputError(`Tool ${name} not found`);
     }
 
-    if (name in listers) {
-      const result = await listers[name as keyof typeof listers](lara);
-      return {
-        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-      };
-    }
-
-    logger.warn(`Requested a tool with name ${name}, but it was not found`);
-    throw new InvalidInputError(`Tool ${name} not found`);
+    return {
+      structuredContent: toStructuredContent(result),
+      content: [{ type: "text", text: narrate(name, args, result) }],
+    };
   } catch (error) {
     if (error instanceof z.ZodError) {
       const fieldErrors = error.issues
@@ -144,7 +210,9 @@ const toolDefinitions = [
       title: "Detect language",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: true,
     },
+    _meta: invocationMeta("Detecting language…", "Language detected"),
   },
   {
     name: "translate",
@@ -156,7 +224,9 @@ const toolDefinitions = [
       title: "Translate text",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: true,
     },
+    _meta: invocationMeta("Translating…", "Translation ready"),
   },
   {
     name: "create_memory",
@@ -167,6 +237,7 @@ const toolDefinitions = [
       title: "Create translation memory",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -178,6 +249,7 @@ const toolDefinitions = [
       title: "Delete translation memory",
       readOnlyHint: false,
       destructiveHint: true,
+      openWorldHint: false,
     },
   },
   {
@@ -189,6 +261,7 @@ const toolDefinitions = [
       title: "Rename translation memory",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -200,6 +273,7 @@ const toolDefinitions = [
       title: "Add translation unit to memory",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -211,6 +285,7 @@ const toolDefinitions = [
       title: "Delete translation unit from memory",
       readOnlyHint: false,
       destructiveHint: true,
+      openWorldHint: false,
     },
   },
   {
@@ -222,7 +297,9 @@ const toolDefinitions = [
       title: "Import TMX file",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
+    _meta: invocationMeta("Queuing TMX import…", "TMX import queued"),
   },
   {
     name: "check_import_status",
@@ -233,7 +310,9 @@ const toolDefinitions = [
       title: "Check TMX import status",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
+    _meta: invocationMeta("Checking import status…", "Status retrieved"),
   },
   {
     name: "list_memories",
@@ -244,6 +323,7 @@ const toolDefinitions = [
       title: "List translation memories",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -255,6 +335,7 @@ const toolDefinitions = [
       title: "List supported languages",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -266,6 +347,7 @@ const toolDefinitions = [
       title: "List glossaries",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -277,6 +359,7 @@ const toolDefinitions = [
       title: "Get glossary",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -288,6 +371,7 @@ const toolDefinitions = [
       title: "Create glossary",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -299,6 +383,7 @@ const toolDefinitions = [
       title: "Rename glossary",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -310,6 +395,7 @@ const toolDefinitions = [
       title: "Delete glossary",
       readOnlyHint: false,
       destructiveHint: true,
+      openWorldHint: false,
     },
   },
   {
@@ -321,7 +407,9 @@ const toolDefinitions = [
       title: "Import glossary CSV",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
+    _meta: invocationMeta("Queuing glossary import…", "Glossary import queued"),
   },
   {
     name: "check_glossary_import_status",
@@ -332,7 +420,9 @@ const toolDefinitions = [
       title: "Check glossary import status",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
+    _meta: invocationMeta("Checking glossary import status…", "Status retrieved"),
   },
   {
     name: "export_glossary",
@@ -343,7 +433,9 @@ const toolDefinitions = [
       title: "Export glossary as CSV",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
+    _meta: invocationMeta("Exporting glossary…", "Glossary exported"),
   },
   {
     name: "get_glossary_counts",
@@ -354,6 +446,7 @@ const toolDefinitions = [
       title: "Get glossary entry count",
       readOnlyHint: true,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -365,6 +458,7 @@ const toolDefinitions = [
       title: "Add or replace glossary entry",
       readOnlyHint: false,
       destructiveHint: false,
+      openWorldHint: false,
     },
   },
   {
@@ -376,6 +470,7 @@ const toolDefinitions = [
       title: "Delete glossary entry",
       readOnlyHint: false,
       destructiveHint: true,
+      openWorldHint: false,
     },
   },
 ];

--- a/src/rest/routes/mcp.ts
+++ b/src/rest/routes/mcp.ts
@@ -5,7 +5,6 @@ import getMcpServer from "#mcp/server";
 import {
   InvalidCredentialsError,
   InvalidInputError,
-  MethodNotAllowedError,
   ServerException,
 } from "#exception";
 import { logger } from "#logger";
@@ -48,16 +47,16 @@ function mcpRouter(restServer: RestServer): express.Router {
     }
   });
 
+  // The MCP Streamable HTTP server→client SSE stream (GET) and session
+  // termination (DELETE) are optional capabilities this server does not
+  // implement. The spec requires 405 so clients fall back gracefully; any
+  // other status (notably 400) is treated as a hard protocol error.
   router.get("/", (_req, res) => {
-    logger.debug("Received GET request on /v1, sending MethodNotAllowedError");
-    restServer.sendJsonRpc(res, new MethodNotAllowedError());
+    res.status(405).set("Allow", "POST").end();
   });
 
   router.delete("/", (_req, res) => {
-    logger.debug(
-      "Received DELETE request on /v1, sending MethodNotAllowedError"
-    );
-    restServer.sendJsonRpc(res, new MethodNotAllowedError());
+    res.status(405).set("Allow", "POST").end();
   });
 
   return router;


### PR DESCRIPTION
## Summary
- GET/DELETE `/v1` now return **405** with `Allow: POST` and empty body so MCP clients fall back gracefully on the optional SSE / session-termination endpoints (any other status, notably 400, is treated as a hard protocol error).
- `CallTool` returns `structuredContent` plus a short narrated text response instead of raw `JSON.stringify` output.
- Adds `openWorldHint` to every tool annotation and `_meta` invocation strings (`openai/toolInvocation/{invoking,invoked}`) on long-running tools — required for ChatGPT Apps SDK / MCP directory compliance.
- Removes the now-unused `MethodNotAllowedError` exception class.