### PR TITLE
feat: declare outputSchema for every MCP tool

### DIFF
--- a/src/__tests__/tools/get_glossary.test.ts
+++ b/src/__tests__/tools/get_glossary.test.ts
@@ -50,14 +50,14 @@ describe('getGlossary', () => {
     const result = await getGlossary({ id: 'gls_xyz123' }, mockTranslator as any as Translator);
 
     expect(mockTranslator.glossaries.get).toHaveBeenCalledWith('gls_xyz123');
-    expect(result).toEqual(mockGlossary);
+    expect(result).toEqual({ glossary: mockGlossary });
   });
 
-  it('should return null for non-existent glossary', async () => {
+  it('should return { glossary: null } for non-existent glossary', async () => {
     mockTranslator.glossaries.get.mockResolvedValue(null);
 
     const result = await getGlossary({ id: 'gls_nonexistent' }, mockTranslator as any as Translator);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ glossary: null });
   });
 });

--- a/src/__tests__/tools/output_schemas.test.ts
+++ b/src/__tests__/tools/output_schemas.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { Translator } from "@translated/lara";
+import type { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
+
+// Stub the logger before importing `mcp/tools.js`: the real logger pulls in
+// `src/env.ts`, which parses `process.env` at module load.
+vi.mock("#logger", () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@translated/lara", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@translated/lara")>();
+  const { createMockTranslator } = await import("../utils/mocks.js");
+  return {
+    ...actual,
+    Translator: vi.fn(() => createMockTranslator()),
+  };
+});
+
+import { CallTool, ListTools } from "../../mcp/tools.js";
+import { listMemoriesOutputSchema } from "../../mcp/tools/list_memories.js";
+import { createMemoryOutputSchema } from "../../mcp/tools/create_memory.js";
+import { getGlossaryOutputSchema } from "../../mcp/tools/get_glossary.js";
+import type { MockTranslator } from "../utils/mocks.js";
+
+function makeRequest(
+  name: string,
+  args: Record<string, unknown> = {}
+): CallToolRequest {
+  return {
+    method: "tools/call",
+    params: { name, arguments: args },
+  } as CallToolRequest;
+}
+
+describe("Tool outputSchema declarations", () => {
+  it("every tool advertises a valid outputSchema", async () => {
+    const { tools } = await ListTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    for (const tool of tools as Tool[]) {
+      const schema = (tool as Tool & { outputSchema?: unknown })
+        .outputSchema;
+      expect(
+        schema,
+        `tool "${tool.name}" is missing outputSchema`
+      ).toBeDefined();
+      expect(schema, `tool "${tool.name}" outputSchema`).toBeTypeOf("object");
+
+      const s = schema as Record<string, unknown>;
+      // MCP SDK's ToolSchema (types.d.ts) requires outputSchema's root to be
+      // type: "object". A bare anyOf/oneOf at the root would be rejected by
+      // strict clients that parse tools/list against the published schema.
+      expect(
+        s.type,
+        `tool "${tool.name}" outputSchema root must be type:"object"`
+      ).toBe("object");
+    }
+  });
+});
+
+describe("structuredContent conforms to outputSchema", () => {
+  let mockTranslator: MockTranslator;
+
+  beforeEach(() => {
+    mockTranslator = new (Translator as any)();
+  });
+
+  it("list_memories result matches listMemoriesOutputSchema", async () => {
+    const memory = {
+      id: "mem_1",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      sharedAt: "2026-01-02T00:00:00Z",
+      name: "M1",
+      ownerId: "user_1",
+      collaboratorsCount: 0,
+      isPersonal: true,
+    };
+    mockTranslator.memories.list.mockResolvedValue([memory]);
+
+    const res = await CallTool(
+      makeRequest("list_memories"),
+      mockTranslator as any as Translator
+    );
+
+    expect(() =>
+      listMemoriesOutputSchema.parse(res.structuredContent)
+    ).not.toThrow();
+  });
+
+  it("create_memory result matches createMemoryOutputSchema", async () => {
+    const memory = {
+      id: "mem_42",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      sharedAt: "2026-01-02T00:00:00Z",
+      name: "brand_names",
+      ownerId: "user_1",
+      collaboratorsCount: 0,
+      isPersonal: true,
+    };
+    mockTranslator.memories.create.mockResolvedValue(memory);
+
+    const res = await CallTool(
+      makeRequest("create_memory", { name: "brand_names" }),
+      mockTranslator as any as Translator
+    );
+
+    expect(() =>
+      createMemoryOutputSchema.parse(res.structuredContent)
+    ).not.toThrow();
+  });
+
+  it("get_glossary result matches the schema for both hit and miss", async () => {
+    const glossary = {
+      id: "gls_abc",
+      name: "Brand",
+      ownerId: "user_1",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-02T00:00:00Z",
+      isPersonal: true,
+    };
+    mockTranslator.glossaries.get.mockResolvedValueOnce(glossary);
+    const hit = await CallTool(
+      makeRequest("get_glossary", { id: "gls_abc" }),
+      mockTranslator as any as Translator
+    );
+    expect(() =>
+      getGlossaryOutputSchema.parse(hit.structuredContent)
+    ).not.toThrow();
+
+    mockTranslator.glossaries.get.mockResolvedValueOnce(null);
+    const miss = await CallTool(
+      makeRequest("get_glossary", { id: "gls_missing" }),
+      mockTranslator as any as Translator
+    );
+    expect(miss.structuredContent).toEqual({ glossary: null });
+    expect(() =>
+      getGlossaryOutputSchema.parse(miss.structuredContent)
+    ).not.toThrow();
+  });
+});

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -8,36 +8,112 @@ import * as z from "zod/v4";
 import {
   addTranslation,
   addTranslationSchema,
+  addTranslationOutputSchema,
 } from "./tools/add_translation.js";
 import {
   checkImportStatus,
   checkImportStatusSchema,
+  checkImportStatusOutputSchema,
 } from "./tools/check_import_status.js";
-import { createMemory, createMemorySchema } from "./tools/create_memory.js";
-import { deleteMemory, deleteMemorySchema } from "./tools/delete_memory.js";
+import {
+  createMemory,
+  createMemorySchema,
+  createMemoryOutputSchema,
+} from "./tools/create_memory.js";
+import {
+  deleteMemory,
+  deleteMemorySchema,
+  deleteMemoryOutputSchema,
+} from "./tools/delete_memory.js";
 import {
   deleteTranslation,
   deleteTranslationSchema,
+  deleteTranslationOutputSchema,
 } from "./tools/delete_translation.js";
-import { importTmx, importTmxSchema } from "./tools/import_tmx.js";
-import { listLanguages, listLanguagesSchema } from "./tools/list_languages.js";
-import { listMemories, listMemoriesSchema } from "./tools/list_memories.js";
-import { listGlossaries, listGlossariesSchema } from "./tools/list_glossaries.js";
-import { getGlossary, getGlossarySchema } from "./tools/get_glossary.js";
-import { createGlossary, createGlossarySchema } from "./tools/create_glossary.js";
-import { updateGlossary, updateGlossarySchema } from "./tools/update_glossary.js";
-import { deleteGlossary, deleteGlossarySchema } from "./tools/delete_glossary.js";
-import { importGlossaryCsv, importGlossaryCsvSchema } from "./tools/import_glossary_csv.js";
-import { checkGlossaryImportStatus, checkGlossaryImportStatusSchema } from "./tools/check_glossary_import_status.js";
-import { exportGlossary, exportGlossarySchema } from "./tools/export_glossary.js";
-import { getGlossaryCounts, getGlossaryCountsSchema } from "./tools/get_glossary_counts.js";
-import { addGlossaryEntry, addGlossaryEntrySchema } from "./tools/add_glossary_entry.js";
-import { deleteGlossaryEntry, deleteGlossaryEntrySchema } from "./tools/delete_glossary_entry.js";
-import { detectLanguage, detectLanguageSchema } from "./tools/detect_language.js";
-import { translateHandler, translateSchema } from "./tools/translate.js";
+import {
+  importTmx,
+  importTmxSchema,
+  importTmxOutputSchema,
+} from "./tools/import_tmx.js";
+import {
+  listLanguages,
+  listLanguagesSchema,
+  listLanguagesOutputSchema,
+} from "./tools/list_languages.js";
+import {
+  listMemories,
+  listMemoriesSchema,
+  listMemoriesOutputSchema,
+} from "./tools/list_memories.js";
+import {
+  listGlossaries,
+  listGlossariesSchema,
+  listGlossariesOutputSchema,
+} from "./tools/list_glossaries.js";
+import {
+  getGlossary,
+  getGlossarySchema,
+  getGlossaryOutputSchema,
+} from "./tools/get_glossary.js";
+import {
+  createGlossary,
+  createGlossarySchema,
+  createGlossaryOutputSchema,
+} from "./tools/create_glossary.js";
+import {
+  updateGlossary,
+  updateGlossarySchema,
+  updateGlossaryOutputSchema,
+} from "./tools/update_glossary.js";
+import {
+  deleteGlossary,
+  deleteGlossarySchema,
+  deleteGlossaryOutputSchema,
+} from "./tools/delete_glossary.js";
+import {
+  importGlossaryCsv,
+  importGlossaryCsvSchema,
+  importGlossaryCsvOutputSchema,
+} from "./tools/import_glossary_csv.js";
+import {
+  checkGlossaryImportStatus,
+  checkGlossaryImportStatusSchema,
+  checkGlossaryImportStatusOutputSchema,
+} from "./tools/check_glossary_import_status.js";
+import {
+  exportGlossary,
+  exportGlossarySchema,
+  exportGlossaryOutputSchema,
+} from "./tools/export_glossary.js";
+import {
+  getGlossaryCounts,
+  getGlossaryCountsSchema,
+  getGlossaryCountsOutputSchema,
+} from "./tools/get_glossary_counts.js";
+import {
+  addGlossaryEntry,
+  addGlossaryEntrySchema,
+  addGlossaryEntryOutputSchema,
+} from "./tools/add_glossary_entry.js";
+import {
+  deleteGlossaryEntry,
+  deleteGlossaryEntrySchema,
+  deleteGlossaryEntryOutputSchema,
+} from "./tools/delete_glossary_entry.js";
+import {
+  detectLanguage,
+  detectLanguageSchema,
+  detectLanguageOutputSchema,
+} from "./tools/detect_language.js";
+import {
+  translateHandler,
+  translateSchema,
+  translateOutputSchema,
+} from "./tools/translate.js";
 import {
   updateMemory,
   updateMemorySchema,
+  updateMemoryOutputSchema,
 } from "./tools/update_memory.tool.js";
 import { InvalidInputError } from "#exception";
 import { logger } from "#logger";
@@ -75,8 +151,12 @@ const listers: Record<string, Lister> = {
 
 function toStructuredContent(result: unknown): Record<string, unknown> {
   if (Array.isArray(result)) return { items: result };
-  if (result !== null && typeof result === "object") return result as Record<string, unknown>;
-  return { value: result };
+  if (result !== null && result !== undefined && typeof result === "object") {
+    return result as Record<string, unknown>;
+  }
+  // Normalize undefined to null so the wire payload always carries the key
+  // explicitly (JSON.stringify drops keys whose value is undefined).
+  return { value: result ?? null };
 }
 
 function invocationMeta(invoking: string, invoked: string) {
@@ -117,7 +197,7 @@ function narrate(name: string, args: any, result: any): string {
     case "list_glossaries":
       return `Found ${Array.isArray(result) ? result.length : 0} glossaries`;
     case "get_glossary":
-      return `Retrieved glossary "${result?.name ?? args?.id ?? ""}"`;
+      return `Retrieved glossary "${result?.glossary?.name ?? args?.id ?? ""}"`;
     case "create_glossary":
       return `Created glossary "${result?.name ?? args?.name ?? ""}"`;
     case "update_glossary":
@@ -160,9 +240,17 @@ async function CallTool(
       throw new InvalidInputError(`Tool ${name} not found`);
     }
 
+    const structuredContent = toStructuredContent(result);
     return {
-      structuredContent: toStructuredContent(result),
-      content: [{ type: "text", text: narrate(name, args, result) }],
+      structuredContent,
+      // MCP spec: when outputSchema is declared, the server SHOULD also return
+      // the serialized JSON in a TextContent block for legacy clients that
+      // don't read structuredContent. The narration stays as the first block
+      // so display-oriented clients keep their short summary.
+      content: [
+        { type: "text", text: narrate(name, args, result) },
+        { type: "text", text: JSON.stringify(structuredContent) },
+      ],
     };
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -206,6 +294,7 @@ const toolDefinitions = [
     description:
       "Detects the language of the provided text. Returns the detected language, content type, and a list of predictions with confidence scores. Accepts a single string or an array of strings (up to 128 elements).",
     inputSchema: z.toJSONSchema(detectLanguageSchema),
+    outputSchema: z.toJSONSchema(detectLanguageOutputSchema),
     annotations: {
       title: "Detect language",
       readOnlyHint: true,
@@ -220,6 +309,7 @@ const toolDefinitions = [
       "Translate text between languages using Lara Translate. Supports language detection, context-aware translations, translation memories, and glossaries. " +
       "The optional 'instructions' parameter accepts short localization directives (e.g., 'Translate formally') — only provide them when the content specifically requires tone, formality, or terminology adjustments.",
     inputSchema: z.toJSONSchema(translateSchema),
+    outputSchema: z.toJSONSchema(translateOutputSchema),
     annotations: {
       title: "Translate text",
       readOnlyHint: true,
@@ -233,6 +323,7 @@ const toolDefinitions = [
     description:
       "Create a translation memory with a custom name in your Lara Translate account. Translation memories store pairs of source and target text segments (translation units) for reuse in future translations.",
     inputSchema: z.toJSONSchema(createMemorySchema),
+    outputSchema: z.toJSONSchema(createMemoryOutputSchema),
     annotations: {
       title: "Create translation memory",
       readOnlyHint: false,
@@ -245,6 +336,7 @@ const toolDefinitions = [
     description:
       "Deletes a translation memory from your Lara Translate account.",
     inputSchema: z.toJSONSchema(deleteMemorySchema),
+    outputSchema: z.toJSONSchema(deleteMemoryOutputSchema),
     annotations: {
       title: "Delete translation memory",
       readOnlyHint: false,
@@ -257,6 +349,7 @@ const toolDefinitions = [
     description:
       "Updates a translation memory in your Lara Translate account.",
     inputSchema: z.toJSONSchema(updateMemorySchema),
+    outputSchema: z.toJSONSchema(updateMemoryOutputSchema),
     annotations: {
       title: "Rename translation memory",
       readOnlyHint: false,
@@ -269,6 +362,7 @@ const toolDefinitions = [
     description:
       "Adds a translation to a translation memory in your Lara Translate account.",
     inputSchema: z.toJSONSchema(addTranslationSchema),
+    outputSchema: z.toJSONSchema(addTranslationOutputSchema),
     annotations: {
       title: "Add translation unit to memory",
       readOnlyHint: false,
@@ -281,6 +375,7 @@ const toolDefinitions = [
     description:
       "Deletes a translation from a translation memory in your Lara Translate account.",
     inputSchema: z.toJSONSchema(deleteTranslationSchema),
+    outputSchema: z.toJSONSchema(deleteTranslationOutputSchema),
     annotations: {
       title: "Delete translation unit from memory",
       readOnlyHint: false,
@@ -293,6 +388,7 @@ const toolDefinitions = [
     description:
       "Imports a TMX file into a translation memory. This is an async operation that returns an import job object containing an import_id. Poll with check_import_status using the returned import_id until the import is complete.",
     inputSchema: z.toJSONSchema(importTmxSchema),
+    outputSchema: z.toJSONSchema(importTmxOutputSchema),
     annotations: {
       title: "Import TMX file",
       readOnlyHint: false,
@@ -306,6 +402,7 @@ const toolDefinitions = [
     description:
       "Checks the status of a TMX import job started by import_tmx. Poll this tool with the import_id returned from import_tmx until the import is complete. The response includes a progress field to track completion.",
     inputSchema: z.toJSONSchema(checkImportStatusSchema),
+    outputSchema: z.toJSONSchema(checkImportStatusOutputSchema),
     annotations: {
       title: "Check TMX import status",
       readOnlyHint: true,
@@ -319,6 +416,7 @@ const toolDefinitions = [
     description:
       "Lists all translation memories in your Lara Translate account.",
     inputSchema: z.toJSONSchema(listMemoriesSchema),
+    outputSchema: z.toJSONSchema(listMemoriesOutputSchema),
     annotations: {
       title: "List translation memories",
       readOnlyHint: true,
@@ -331,6 +429,7 @@ const toolDefinitions = [
     description:
       "Lists all supported languages in your Lara Translate account.",
     inputSchema: z.toJSONSchema(listLanguagesSchema),
+    outputSchema: z.toJSONSchema(listLanguagesOutputSchema),
     annotations: {
       title: "List supported languages",
       readOnlyHint: true,
@@ -343,6 +442,7 @@ const toolDefinitions = [
     description:
       "Lists all glossaries in your Lara Translate account. Glossaries are collections of terms with their translations that enforce specific terminology during translation.",
     inputSchema: z.toJSONSchema(listGlossariesSchema),
+    outputSchema: z.toJSONSchema(listGlossariesOutputSchema),
     annotations: {
       title: "List glossaries",
       readOnlyHint: true,
@@ -355,6 +455,7 @@ const toolDefinitions = [
     description:
       "Retrieves a specific glossary by ID from your Lara Translate account. Returns null if the glossary is not found.",
     inputSchema: z.toJSONSchema(getGlossarySchema),
+    outputSchema: z.toJSONSchema(getGlossaryOutputSchema),
     annotations: {
       title: "Get glossary",
       readOnlyHint: true,
@@ -367,6 +468,7 @@ const toolDefinitions = [
     description:
       "Create a glossary with a custom name in your Lara Translate account. Glossaries enforce specific terminology during translation.",
     inputSchema: z.toJSONSchema(createGlossarySchema),
+    outputSchema: z.toJSONSchema(createGlossaryOutputSchema),
     annotations: {
       title: "Create glossary",
       readOnlyHint: false,
@@ -379,6 +481,7 @@ const toolDefinitions = [
     description:
       "Updates the name of a glossary in your Lara Translate account.",
     inputSchema: z.toJSONSchema(updateGlossarySchema),
+    outputSchema: z.toJSONSchema(updateGlossaryOutputSchema),
     annotations: {
       title: "Rename glossary",
       readOnlyHint: false,
@@ -391,6 +494,7 @@ const toolDefinitions = [
     description:
       "Deletes a glossary from your Lara Translate account.",
     inputSchema: z.toJSONSchema(deleteGlossarySchema),
+    outputSchema: z.toJSONSchema(deleteGlossaryOutputSchema),
     annotations: {
       title: "Delete glossary",
       readOnlyHint: false,
@@ -403,6 +507,7 @@ const toolDefinitions = [
     description:
       "Imports a CSV file into a glossary. Supports unidirectional and multidirectional formats. This is an async operation that returns an import job object containing an import_id. Poll with check_glossary_import_status using the returned import_id until the import is complete.",
     inputSchema: z.toJSONSchema(importGlossaryCsvSchema),
+    outputSchema: z.toJSONSchema(importGlossaryCsvOutputSchema),
     annotations: {
       title: "Import glossary CSV",
       readOnlyHint: false,
@@ -416,6 +521,7 @@ const toolDefinitions = [
     description:
       "Checks the status of a glossary CSV import job started by import_glossary_csv. Poll this tool with the import_id returned from import_glossary_csv until the import is complete.",
     inputSchema: z.toJSONSchema(checkGlossaryImportStatusSchema),
+    outputSchema: z.toJSONSchema(checkGlossaryImportStatusOutputSchema),
     annotations: {
       title: "Check glossary import status",
       readOnlyHint: true,
@@ -429,6 +535,7 @@ const toolDefinitions = [
     description:
       "Exports a glossary as CSV from your Lara Translate account. Supports unidirectional and multidirectional formats.",
     inputSchema: z.toJSONSchema(exportGlossarySchema),
+    outputSchema: z.toJSONSchema(exportGlossaryOutputSchema),
     annotations: {
       title: "Export glossary as CSV",
       readOnlyHint: true,
@@ -442,6 +549,7 @@ const toolDefinitions = [
     description:
       "Retrieves the term and language counts for a glossary in your Lara Translate account.",
     inputSchema: z.toJSONSchema(getGlossaryCountsSchema),
+    outputSchema: z.toJSONSchema(getGlossaryCountsOutputSchema),
     annotations: {
       title: "Get glossary entry count",
       readOnlyHint: true,
@@ -454,6 +562,7 @@ const toolDefinitions = [
     description:
       "Adds or replaces an entry in a glossary in your Lara Translate account. Supports both monodirectional and multidirectional glossaries.",
     inputSchema: z.toJSONSchema(addGlossaryEntrySchema),
+    outputSchema: z.toJSONSchema(addGlossaryEntryOutputSchema),
     annotations: {
       title: "Add or replace glossary entry",
       readOnlyHint: false,
@@ -466,6 +575,7 @@ const toolDefinitions = [
     description:
       "Deletes an entry from a glossary in your Lara Translate account. Use term for monodirectional glossaries or guid for multidirectional glossaries.",
     inputSchema: z.toJSONSchema(deleteGlossaryEntrySchema),
+    outputSchema: z.toJSONSchema(deleteGlossaryEntryOutputSchema),
     annotations: {
       title: "Delete glossary entry",
       readOnlyHint: false,

--- a/src/mcp/tools/_schemas.ts
+++ b/src/mcp/tools/_schemas.ts
@@ -1,0 +1,131 @@
+import { z } from "zod/v4";
+
+const isoDate = z
+  .string()
+  .describe("ISO 8601 timestamp");
+
+export const textBlockSchema = z
+  .object({
+    text: z.string().describe("Text content of the block"),
+    translatable: z
+      .boolean()
+      .optional()
+      .describe(
+        "Whether the block should be translated. Omitted on response blocks the engine treats as wholly translatable."
+      ),
+  })
+  .loose();
+
+export const memorySchema = z
+  .object({
+    id: z.string().describe("Unique memory identifier (format: mem_*)"),
+    createdAt: isoDate,
+    updatedAt: isoDate,
+    sharedAt: isoDate,
+    name: z.string().describe("Display name of the memory"),
+    externalId: z
+      .string()
+      .optional()
+      .describe("External identifier (e.g. MyMemory ID) when imported"),
+    secret: z.string().optional().describe("Memory secret, if any"),
+    ownerId: z.string().describe("Identifier of the memory owner"),
+    collaboratorsCount: z
+      .number()
+      .int()
+      .describe("Number of collaborators with access to the memory"),
+    isPersonal: z
+      .boolean()
+      .describe("True if the memory is private to the owner"),
+  })
+  .loose();
+
+export const memoryImportSchema = z
+  .object({
+    id: z.string().describe("Import job identifier"),
+    begin: z.number().optional().describe("Begin offset of the import"),
+    end: z.number().optional().describe("End offset of the import"),
+    channel: z
+      .number()
+      .optional()
+      .describe("Channel identifier used by the import"),
+    size: z
+      .number()
+      .optional()
+      .describe("Total number of units in the import"),
+    progress: z
+      .number()
+      .optional()
+      .describe("Import progress between 0 and 1 (1 means complete)"),
+  })
+  .loose();
+
+export const glossarySchema = z
+  .object({
+    id: z.string().describe("Unique glossary identifier (format: gls_*)"),
+    name: z.string().describe("Display name of the glossary"),
+    ownerId: z.string().describe("Identifier of the glossary owner"),
+    createdAt: isoDate,
+    updatedAt: isoDate,
+    isPersonal: z
+      .boolean()
+      .describe("True if the glossary is private to the owner"),
+  })
+  .loose();
+
+export const glossaryImportSchema = z
+  .object({
+    id: z.string().describe("Import job identifier"),
+    begin: z.number().optional().describe("Begin offset of the import"),
+    end: z.number().optional().describe("End offset of the import"),
+    channel: z
+      .number()
+      .optional()
+      .describe("Channel identifier used by the import"),
+    size: z
+      .number()
+      .optional()
+      .describe("Total number of entries in the import"),
+    progress: z
+      .number()
+      .optional()
+      .describe("Import progress between 0 and 1 (1 means complete)"),
+  })
+  .loose();
+
+export const glossaryCountsSchema = z
+  .object({
+    unidirectional: z
+      .record(z.string(), z.number())
+      .optional()
+      .describe(
+        "Entry counts keyed by language code for unidirectional glossaries"
+      ),
+    multidirectional: z
+      .number()
+      .optional()
+      .describe("Total entry count for multidirectional glossaries"),
+  })
+  .loose();
+
+export const detectResultSchema = z
+  .object({
+    language: z
+      .string()
+      .describe("Detected language code (e.g., 'en-US')"),
+    contentType: z
+      .string()
+      .describe("Content type of the analysed text"),
+    predictions: z
+      .array(
+        z
+          .object({
+            language: z.string().describe("Candidate language code"),
+            confidence: z
+              .number()
+              .describe("Confidence score between 0 and 1"),
+          })
+          .loose()
+      )
+      .describe("Ranked list of candidate languages with confidence scores"),
+  })
+  .loose();

--- a/src/mcp/tools/add_glossary_entry.ts
+++ b/src/mcp/tools/add_glossary_entry.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { glossaryImportSchema } from "./_schemas.js";
+
+export const addGlossaryEntryOutputSchema = glossaryImportSchema;
 
 export const addGlossaryEntrySchema = z.object({
   id: z.string()

--- a/src/mcp/tools/add_translation.ts
+++ b/src/mcp/tools/add_translation.ts
@@ -1,6 +1,9 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 import { InvalidInputError } from "#exception";
+import { memoryImportSchema } from "./_schemas.js";
+
+export const addTranslationOutputSchema = memoryImportSchema;
 
 export const addTranslationSchema = z.object({
   id: z

--- a/src/mcp/tools/check_glossary_import_status.ts
+++ b/src/mcp/tools/check_glossary_import_status.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { glossaryImportSchema } from "./_schemas.js";
+
+export const checkGlossaryImportStatusOutputSchema = glossaryImportSchema;
 
 export const checkGlossaryImportStatusSchema = z.object({
   id: z.string().describe("The ID of the glossary import job"),

--- a/src/mcp/tools/check_import_status.ts
+++ b/src/mcp/tools/check_import_status.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { memoryImportSchema } from "./_schemas.js";
+
+export const checkImportStatusOutputSchema = memoryImportSchema;
 
 export const checkImportStatusSchema = z.object({
   id: z.string().describe("The ID of the import job"),

--- a/src/mcp/tools/create_glossary.ts
+++ b/src/mcp/tools/create_glossary.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { glossarySchema } from "./_schemas.js";
+
+export const createGlossaryOutputSchema = glossarySchema;
 
 export const createGlossarySchema = z.object({
   name: z

--- a/src/mcp/tools/create_memory.ts
+++ b/src/mcp/tools/create_memory.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { memorySchema } from "./_schemas.js";
+
+export const createMemoryOutputSchema = memorySchema;
 
 export const createMemorySchema = z.object({
   name: z

--- a/src/mcp/tools/delete_glossary.ts
+++ b/src/mcp/tools/delete_glossary.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { glossarySchema } from "./_schemas.js";
+
+export const deleteGlossaryOutputSchema = glossarySchema;
 
 export const deleteGlossarySchema = z.object({
   id: z.string()

--- a/src/mcp/tools/delete_glossary_entry.ts
+++ b/src/mcp/tools/delete_glossary_entry.ts
@@ -1,6 +1,9 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 import { InvalidInputError } from "#exception";
+import { glossaryImportSchema } from "./_schemas.js";
+
+export const deleteGlossaryEntryOutputSchema = glossaryImportSchema;
 
 export const deleteGlossaryEntrySchema = z.object({
   id: z.string()

--- a/src/mcp/tools/delete_memory.ts
+++ b/src/mcp/tools/delete_memory.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { memorySchema } from "./_schemas.js";
+
+export const deleteMemoryOutputSchema = memorySchema;
 
 export const deleteMemorySchema = z.object({
   id: z

--- a/src/mcp/tools/delete_translation.ts
+++ b/src/mcp/tools/delete_translation.ts
@@ -1,6 +1,9 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 import { InvalidInputError } from "#exception";
+import { memoryImportSchema } from "./_schemas.js";
+
+export const deleteTranslationOutputSchema = memoryImportSchema;
 
 export const deleteTranslationSchema = z.object({
   id: z

--- a/src/mcp/tools/detect_language.ts
+++ b/src/mcp/tools/detect_language.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { detectResultSchema } from "./_schemas.js";
+
+export const detectLanguageOutputSchema = detectResultSchema;
 
 export const detectLanguageSchema = z.object({
   text: z

--- a/src/mcp/tools/export_glossary.ts
+++ b/src/mcp/tools/export_glossary.ts
@@ -1,6 +1,12 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 
+export const exportGlossaryOutputSchema = z.object({
+  value: z
+    .string()
+    .describe("The exported glossary content serialised as CSV"),
+});
+
 export const exportGlossarySchema = z.object({
   id: z.string()
     .min(1)

--- a/src/mcp/tools/get_glossary.ts
+++ b/src/mcp/tools/get_glossary.ts
@@ -1,5 +1,12 @@
 import { z } from "zod/v4";
 import { Translator } from "@translated/lara";
+import { glossarySchema } from "./_schemas.js";
+
+export const getGlossaryOutputSchema = z.object({
+  glossary: glossarySchema
+    .nullable()
+    .describe("The requested glossary, or null when no glossary has that id"),
+});
 
 export const getGlossarySchema = z.object({
   id: z.string()
@@ -13,5 +20,6 @@ export async function getGlossary(args: unknown, lara: Translator) {
   const validatedArgs = getGlossarySchema.parse(args);
   const { id } = validatedArgs;
 
-  return await lara.glossaries.get(id);
+  const glossary = await lara.glossaries.get(id);
+  return { glossary: glossary ?? null };
 }

--- a/src/mcp/tools/get_glossary_counts.ts
+++ b/src/mcp/tools/get_glossary_counts.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { glossaryCountsSchema } from "./_schemas.js";
+
+export const getGlossaryCountsOutputSchema = glossaryCountsSchema;
 
 export const getGlossaryCountsSchema = z.object({
   id: z.string()

--- a/src/mcp/tools/import_glossary_csv.ts
+++ b/src/mcp/tools/import_glossary_csv.ts
@@ -4,6 +4,9 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { InvalidInputError } from "#exception";
+import { glossaryImportSchema } from "./_schemas.js";
+
+export const importGlossaryCsvOutputSchema = glossaryImportSchema;
 
 export const importGlossaryCsvSchema = z.object({
   id: z.string()

--- a/src/mcp/tools/import_tmx.ts
+++ b/src/mcp/tools/import_tmx.ts
@@ -4,6 +4,9 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { InvalidInputError } from "#exception";
+import { memoryImportSchema } from "./_schemas.js";
+
+export const importTmxOutputSchema = memoryImportSchema;
 
 export const importTmxSchema = z.object({
   id: z

--- a/src/mcp/tools/list_glossaries.ts
+++ b/src/mcp/tools/list_glossaries.ts
@@ -1,7 +1,14 @@
 import { z } from "zod/v4";
 import { Translator } from "@translated/lara";
+import { glossarySchema } from "./_schemas.js";
 
 export const listGlossariesSchema = z.object({});
+
+export const listGlossariesOutputSchema = z.object({
+  items: z
+    .array(glossarySchema)
+    .describe("Glossaries accessible to the authenticated account"),
+});
 
 export async function listGlossaries(lara: Translator) {
     return await lara.glossaries.list();

--- a/src/mcp/tools/list_languages.ts
+++ b/src/mcp/tools/list_languages.ts
@@ -3,6 +3,12 @@ import { Translator } from "@translated/lara";
 
 export const listLanguagesSchema = z.object({});
 
+export const listLanguagesOutputSchema = z.object({
+  items: z
+    .array(z.string())
+    .describe("Supported language codes (e.g., 'en-US', 'it-IT')"),
+});
+
 export async function listLanguages(lara: Translator) {
   return await lara.getLanguages();
 }

--- a/src/mcp/tools/list_memories.ts
+++ b/src/mcp/tools/list_memories.ts
@@ -1,7 +1,14 @@
 import { z } from "zod/v4";
 import { Translator } from "@translated/lara";
+import { memorySchema } from "./_schemas.js";
 
 export const listMemoriesSchema = z.object({})
+
+export const listMemoriesOutputSchema = z.object({
+  items: z
+    .array(memorySchema)
+    .describe("Translation memories accessible to the authenticated account"),
+});
 
 export async function listMemories(lara: Translator) {
     return await lara.memories.list()

--- a/src/mcp/tools/translate.ts
+++ b/src/mcp/tools/translate.ts
@@ -1,12 +1,18 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
 import { logger } from "#logger";
+import { textBlockSchema } from "./_schemas.js";
+
+export { textBlockSchema };
 
 const MAX_INSTRUCTION_WORDS = 20;
 
-export const textBlockSchema = z.object({
-  text: z.string(),
-  translatable: z.boolean(),
+export const translateOutputSchema = z.object({
+  items: z
+    .array(textBlockSchema)
+    .describe(
+      "Translated text blocks, in the same order and structure as the input. Blocks marked translatable: false are preserved verbatim."
+    ),
 });
 
 export const translateSchema = z.object({

--- a/src/mcp/tools/update_glossary.ts
+++ b/src/mcp/tools/update_glossary.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { glossarySchema } from "./_schemas.js";
+
+export const updateGlossaryOutputSchema = glossarySchema;
 
 export const updateGlossarySchema = z.object({
   id: z.string()

--- a/src/mcp/tools/update_memory.tool.ts
+++ b/src/mcp/tools/update_memory.tool.ts
@@ -1,5 +1,8 @@
 import { Translator } from "@translated/lara";
 import { z } from "zod/v4";
+import { memorySchema } from "./_schemas.js";
+
+export const updateMemoryOutputSchema = memorySchema;
 
 export const updateMemorySchema = z.object({
   id: z


### PR DESCRIPTION
## Summary
- Adds an MCP `outputSchema` to all 22 tools so the server can be published as a plugin against the MCP draft Tools spec.
- Centralises shared response entities (Memory, Glossary, MemoryImport, GlossaryImport, GlossaryCounts, DetectResult, TextBlock) in `src/mcp/tools/_schemas.ts` and converts each tool's per-call output schema with `z.toJSONSchema`.
- Hardens `CallTool` so structured responses comply with the spec for both modern and legacy clients.

## Changed
- `get_glossary` now returns `{ glossary: Glossary | null }` so the published outputSchema has root `type:"object"` (a Zod union at the root would produce `anyOf:[...]` with no root type, which the MCP SDK's `ToolSchema` rejects).
- `toStructuredContent` coerces `undefined` results to `{ value: null }` so JSON serialisation never silently drops the key.
- `CallTool` emits a second `TextContent` block carrying the JSON-serialised `structuredContent` for legacy clients that don't read `structuredContent`, per the spec's backward-compat clause.
- `textBlockSchema.translatable` is now optional to match `@translated/lara`'s `TextBlock` interface (the engine commonly omits the flag on response blocks).
- `MemoryImport` / `GlossaryImport` schemas mark `begin`, `end`, `channel`, `size`, `progress` optional so freshly-queued import jobs with partial payloads still validate.

## New
- `src/mcp/tools/_schemas.ts` with shared entity schemas, all `.loose()` so future API field additions don't trip strict client validators.
- `outputSchema` declared on every tool definition in `src/mcp/tools.ts`, generated via `z.toJSONSchema(...)` and matching exactly what `toStructuredContent` puts on the wire.
- `src/__tests__/tools/output_schemas.test.ts`: asserts every tool advertises an outputSchema whose root is `type:"object"` (regression guard against future root unions) and validates real `structuredContent` against the Zod schema for `list_memories`, `create_memory`, and `get_glossary` (hit + miss paths).

## Test plan
- [x] `pnpm run build`
- [x] `pnpm test` — 164 tests pass (160 previous + 4 new)
- [ ] Smoke-test via an MCP inspector / Claude Desktop: `tools/list` shows `outputSchema` on every tool; invoking `list_memories`, `translate`, and `get_glossary` returns `structuredContent` matching the advertised schema, plus the JSON mirror in `content[1]`