### PR TITLE
1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translated/lara-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Lara API official MCP server",
   "author": {
     "name": "Translated",

--- a/src/__tests__/server/mcp.server.test.ts
+++ b/src/__tests__/server/mcp.server.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { PACKAGE_VERSION } from "../../version.js";
+
+// Hoisted so it exists before the mock factory runs (the factory fires as soon
+// as anything imports "@translated/lara", which happens transitively before
+// module-scope consts would be initialized).
+const { instances } = vi.hoisted(() => ({ instances: [] as any[] }));
+
+vi.mock("@translated/lara", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@translated/lara")>();
+  return {
+    ...actual,
+    Translator: vi.fn(() => {
+      const instance = { client: { setExtraHeader: vi.fn() } };
+      instances.push(instance);
+      return instance;
+    }),
+  };
+});
+
+const { default: getMcpServer } = await import("../../mcp/server.js");
+
+describe("getMcpServer Lara client headers", () => {
+  beforeEach(() => {
+    instances.length = 0;
+  });
+
+  it("sets X-Lara-Client and X-Lara-Client-Version on every SDK call", () => {
+    getMcpServer("test-id", "test-secret");
+
+    expect(instances).toHaveLength(1);
+    const setExtraHeader = instances[0].client.setExtraHeader;
+
+    expect(setExtraHeader).toHaveBeenCalledWith("X-Lara-Client", "MCP");
+    expect(setExtraHeader).toHaveBeenCalledWith(
+      "X-Lara-Client-Version",
+      PACKAGE_VERSION
+    );
+    expect(setExtraHeader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/utils/mocks.ts
+++ b/src/__tests__/utils/mocks.ts
@@ -46,7 +46,9 @@ export function createMockTranslator() {
       addOrReplaceEntry: vi.fn(),
       deleteEntry: vi.fn(),
     },
-    client: {}
+    client: {
+      setExtraHeader: vi.fn(),
+    }
   };
 }
 

--- a/src/__tests__/version.test.ts
+++ b/src/__tests__/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { PACKAGE_VERSION } from "../version.js";
+
+describe("PACKAGE_VERSION", () => {
+  it("matches the version declared in package.json", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(
+      readFileSync(join(here, "..", "..", "package.json"), "utf8")
+    ) as { version: string };
+
+    expect(PACKAGE_VERSION).toBe(pkg.version);
+    expect(PACKAGE_VERSION).not.toBe("unknown");
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import {
 import { CallTool, ListTools } from "./tools.js";
 import { ListResources, ListResourceTemplates, ReadResource } from "./resources.js";
 import { logger } from "#logger";
+import { PACKAGE_VERSION } from "../version.js";
 
 export default function getMcpServer(
   accessKeyId: string,
@@ -20,10 +21,20 @@ export default function getMcpServer(
   const credentials = new Credentials(accessKeyId, accessKeySecret);
   const lara = new Translator(credentials);
 
+  // Identify MCP-originated traffic to Lara on every SDK request. extraHeaders
+  // are spread into all requests by the SDK transport, so setting them once
+  // here covers translate, glossaries, memories, languages, imports, etc. The
+  // client is protected/internal in the SDK types, hence the narrow cast.
+  const laraClient = (lara as unknown as {
+    client: { setExtraHeader(name: string, value: string): void };
+  }).client;
+  laraClient.setExtraHeader("X-Lara-Client", "MCP");
+  laraClient.setExtraHeader("X-Lara-Client-Version", PACKAGE_VERSION);
+
   const server = new Server(
     {
       name: "Lara Translate",
-      version: "0.0.15",
+      version: PACKAGE_VERSION,
     },
     {
       capabilities: {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,10 +26,16 @@ export default function getMcpServer(
   // here covers translate, glossaries, memories, languages, imports, etc. The
   // client is protected/internal in the SDK types, hence the narrow cast.
   const laraClient = (lara as unknown as {
-    client: { setExtraHeader(name: string, value: string): void };
+    client?: { setExtraHeader?: (name: string, value: string) => void };
   }).client;
-  laraClient.setExtraHeader("X-Lara-Client", "MCP");
-  laraClient.setExtraHeader("X-Lara-Client-Version", PACKAGE_VERSION);
+  if (typeof laraClient?.setExtraHeader === "function") {
+    laraClient.setExtraHeader("X-Lara-Client", "MCP");
+    laraClient.setExtraHeader("X-Lara-Client-Version", PACKAGE_VERSION);
+  } else {
+    logger.warn(
+      "Lara SDK client does not expose setExtraHeader; X-Lara-Client headers not set"
+    );
+  }
 
   const server = new Server(
     {

--- a/src/rest/routes/server-info.ts
+++ b/src/rest/routes/server-info.ts
@@ -1,26 +1,12 @@
-import fs from "node:fs";
-import path from "node:path";
-
 import express from "express";
 import { RestServer } from "#rest/server";
-
-const buildInfoJson: string = fs.readFileSync(
-  path.join(import.meta.dirname, "..", "..", "..", "package.json"),
-  "utf8"
-);
-
-type BuildInfo = {
-  name: string;
-  version: string;
-};
-
-export const BuildInfo: BuildInfo = JSON.parse(buildInfoJson);
+import { PACKAGE_VERSION } from "../../version.js";
 
 export default function serverInfoRouter(rest: RestServer): express.Router {
   const router = express.Router();
 
   router.all("/", (_req, res) => {
-    rest.send(res, { version: BuildInfo.version });
+    rest.send(res, { version: PACKAGE_VERSION });
   });
 
   return router;

--- a/src/version.ts
+++ b/src/version.ts
@@ -11,8 +11,10 @@ function loadPackageVersion(): string {
   try {
     const pkg = JSON.parse(
       readFileSync(join(import.meta.dirname, "..", "package.json"), "utf8")
-    ) as { version: string };
-    return pkg.version;
+    ) as { version?: unknown };
+    return typeof pkg.version === "string" && pkg.version.length > 0
+      ? pkg.version
+      : "unknown";
   } catch {
     return "unknown";
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Read this package's version once at module load so it can be sent as the
+// X-Lara-Client-Version header on every Lara SDK call and reported by the
+// server-info route. package.json sits next to the source dir in dev
+// (src/version.ts) and next to dist/ in the published package (dist/version.js),
+// so "../package.json" resolves in both layouts. Fall back to "unknown" so a
+// missing/unreadable file degrades gracefully instead of crashing on import.
+function loadPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(import.meta.dirname, "..", "package.json"), "utf8")
+    ) as { version: string };
+    return pkg.version;
+  } catch {
+    return "unknown";
+  }
+}
+
+export const PACKAGE_VERSION = loadPackageVersion();


### PR DESCRIPTION
## Changed
- Send `X-Lara-Client: MCP` and `X-Lara-Client-Version: <package version>` headers on **all** Lara SDK calls (translate, glossaries, memories, languages, imports, etc.) by setting them once on the SDK client after construction.
- Report the real package version as the MCP server version instead of the hardcoded `0.0.15`.
- `/server-info` route now reads the version from the shared module.
- Bump version to 1.0.5.