### PR TITLE
chore: emit package type declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "strict": true,
+    "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "baseUrl": ".",


### PR DESCRIPTION
## Summary

- enable TypeScript declaration output so the published `types` path is emitted
- keep the package's existing `main`, `types`, and `files` metadata intact

## Validation

- `corepack pnpm@9.15.9 install --frozen-lockfile --ignore-scripts`
- `corepack pnpm@9.15.9 exec tsc`
- `npm pack --dry-run --ignore-scripts --json` includes `dist/index.d.ts`
- `corepack pnpm@9.15.9 test` passes 28 files / 166 tests

Note: `pnpm build` currently fails on Windows before TypeScript runs because the script uses `rm -rf dist`; I used the equivalent direct `tsc` invocation for validation.
