### PR TITLE
feat: report funnel metrics on channel mcp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,14 @@ TRANSPORT=http
 
 # Logging
 LOGGING_LEVEL=info
+
+# Usage metrics. Both are compiled in with a default, and these override them.
+# Either one empty = telemetry silently off.
+# METRICS_URL=http://localhost:8080
+# METRICS_API_KEY=dev-mcp-key
+
+# Where the installation id is kept. Default: ~/.lara
+# LARA_HOME=/var/lib/lara
+
+# Opt out of usage metrics entirely (https://consoledonottrack.com).
+# DO_NOT_TRACK=1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,9 @@ Core configuration (`src/env.ts`):
 - `HOST` / `PORT` - HTTP server binding (default: `0.0.0.0:3000`)
 - `LARA_ACCESS_KEY_ID` / `LARA_ACCESS_KEY_SECRET` - API credentials (required for STDIO mode)
 - `LOGGING_LEVEL` - Log level: `debug`, `info`, `warn`, `error` (default: `info`)
+- `METRICS_URL` / `METRICS_API_KEY` - Override the compiled-in metrics backend
+- `LARA_HOME` - Where the metrics installation id lives (default: `~/.lara`)
+- `DO_NOT_TRACK` - `1`/`true`/`yes` disables usage metrics entirely
 
 ### Error Handling
 
@@ -145,6 +148,43 @@ Error handling in `src/mcp/tools.ts`:
 - Other unexpected errors are logged internally and returned as generic "An error occurred while processing your request" message
 - Privacy-sensitive translations (with `no_trace=true`) are logged for audit purposes
 
+### Usage Metrics (`src/metrics.ts`)
+
+Funnel telemetry for the `mcp` channel of the Lara integrations monitoring
+backend. Both transports report; the module is self-contained and its failures
+never reach a tool call.
+
+- **Configuration**: `DEFAULT_METRICS_URL` / `DEFAULT_METRICS_API_KEY` are
+  compiled in and overridden by `METRICS_URL` / `METRICS_API_KEY`. Either one
+  empty, an unparseable URL, or `DO_NOT_TRACK` set to `1`/`true`/`yes` and
+  `metricsEnabled()` is false — nothing is measured, queued or written to disk.
+- **Delivery**: `POST /auth/issue-token` (API key, `{ installationId }`) buys a
+  token; events go to `POST /metrics/ingest-events` with it. Batched every 2s
+  behind an `unref`'d timer, one retry on 401 only, requeued on 429/5xx, dropped
+  on any other rejection, queue capped at 10 000. `flushNow()` is awaited once,
+  on shutdown, capped at 2s.
+- **Installation id**: a UUID at `${LARA_HOME ?? ~/.lara}/installation-id`,
+  resolved synchronously at module load. `writeFileSync(..., { flag: "wx" })`
+  settles the race between two processes starting together. An unwritable home
+  falls back to a per-process id. A freshly created file is what triggers the
+  one `install` event.
+- **Events**: `install` (no `accountId`), `auth_success` (deduplicated per
+  account per process — the HTTP transport is stateless and builds a Translator
+  per request), `call_success`, `call_error`, and `auth_fail` beside a
+  `call_error` Lara answered with 401/403.
+- **`accountId`**: the `id` claim of the Lara token the SDK holds, read through
+  `getLaraClient()` in `src/lara-client.ts` (the one cast through the SDK's
+  `protected client`). The SDK authenticates lazily, so it is only knowable
+  after a call has succeeded. No token means no account and **no event** — a
+  made-up id would be a fake account in every dashboard.
+- **`metadata`**: `feature` (`text` / `language_detection` /
+  `resource_management` — a shared vocabulary, values are stable forever),
+  `toolName`, `transport`, and `sourceLang`/`targetLang` on `translate`. Never
+  the translated text, never a credential.
+- **Where it is emitted**: inside `CallTool`'s own try/catch, not from a wrapper
+  around it — `CallTool` rewrites `LaraApiError` into `InvalidInputError` before
+  it escapes, so only there is the original error still available to classify.
+
 ### Logging
 
 The server uses Pino structured logging (`src/logger.ts`). Log level is controlled by `LOGGING_LEVEL` environment variable.
@@ -152,9 +192,16 @@ The server uses Pino structured logging (`src/logger.ts`). Log level is controll
 ## Testing
 
 Tests are located in `src/__tests__/` and mirror the source structure:
-- `tools/` - Individual tool tests (71 total tests)
-- `server/` - REST server tests
+- `tools/` - Individual tool tests
+- `server/` - REST server tests, plus `mcp.metrics.test.ts` for the metrics wiring
+- `metrics.test.ts` - The metrics client in isolation
 - `utils/mocks.ts` - Shared test utilities with Vitest mocks
+
+The two metrics test files deliberately do **not** import `utils/mocks.ts`: its
+hoisted `vi.mock("@translated/lara")` would replace `LaraApiError`/`TimeoutError`,
+which `errorTypeFor` classifies with `instanceof`. They reset modules and
+re-import instead, because the queue, the token and the installation id are
+module state.
 
 Tests use Vitest with coverage reporting (v8 provider).
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,50 @@ Then add to your MCP config:
 
 ---
 
+## Usage Metrics
+
+The server reports anonymous usage events to Lara so we can see how the
+integration is doing: an `install` the first time it runs, `auth_success` /
+`auth_fail` when your credentials are accepted or rejected, and a
+`call_success` / `call_error` per tool call.
+
+**What is sent:** your Lara account id (`acc_...`), the tool name, the source
+and target language tags, how many characters were translated, how long the
+call took, and the server version.
+
+**What is never sent:** the text you translate, your access key, your access
+key secret, and anything else that identifies you or your content.
+
+An installation id (a random UUID, tied to nothing) is generated on first run
+and kept at `~/.lara/installation-id` — set `LARA_HOME` to move it. It exists
+so repeated runs of the same install count as one.
+
+### Opting out
+
+Set `DO_NOT_TRACK` to `1`, `true` or `yes` and nothing is measured, queued,
+written to disk or sent:
+
+```json
+{
+  "mcpServers": {
+    "lara-translate": {
+      "command": "npx",
+      "args": ["-y", "@translated/lara-mcp@latest"],
+      "env": {
+        "LARA_ACCESS_KEY_ID": "<YOUR_ACCESS_KEY_ID>",
+        "LARA_ACCESS_KEY_SECRET": "<YOUR_ACCESS_KEY_SECRET>",
+        "DO_NOT_TRACK": "1"
+      }
+    }
+  }
+}
+```
+
+Metrics never block, slow down or fail a translation: events are batched, sent
+in the background, and a monitoring backend that is down is ignored.
+
+---
+
 ## Support
 
 - For issues with Lara Translate API: visit [Lara Translate Support](https://support.laratranslate.com)

--- a/README.md
+++ b/README.md
@@ -237,9 +237,14 @@ Then add to your MCP config:
 ## Usage Metrics
 
 The server reports anonymous usage events to Lara so we can see how the
-integration is doing: an `install` the first time it runs, `auth_success` /
-`auth_fail` when your credentials are accepted or rejected, and a
-`call_success` / `call_error` per tool call.
+integration is doing: an `install` the first time it runs, an `auth_success`
+the first time your credentials are accepted, and a `call_success` /
+`call_error` per tool call.
+
+Events are reported against your Lara account, which is only known once your
+credentials have been accepted. Credentials Lara rejects outright therefore
+produce **no events at all** — including no `auth_fail`, which is only sent
+when a key that already worked stops being accepted.
 
 **What is sent:** your Lara account id (`acc_...`), the tool name, the source
 and target language tags, how many characters were translated, how long the

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -466,6 +466,71 @@ describe("delivery", () => {
     expect(bodyOf(callsTo(fetchMock, INGEST_URL)[0]).events).toHaveLength(1);
   });
 
+  it("keeps the envelope authoritative over whatever a caller passes", async () => {
+    metrics.logEvent({
+      ...event(),
+      // Not reachable through the public type, but the envelope must win regardless.
+      ...({ channel: "slack", sessionId: "spoofed", eventId: "spoofed" } as any),
+    });
+    await metrics.flushNow();
+
+    const [sent] = bodyOf(callsTo(fetchMock, INGEST_URL)[0]).events;
+    expect(sent.channel).toBe("mcp");
+    expect(sent.sessionId).not.toBe("spoofed");
+    expect(sent.eventId).not.toBe("spoofed");
+  });
+
+  it("stays within the cap when a failed batch goes back on the queue", async () => {
+    // The overshoot only happens if events arrive while a batch is in flight: the batch is out of
+    // the queue, so new events refill it to the cap, and handing the batch back pushes it over.
+    let releaseSend: () => void;
+    const sendInFlight = new Promise<void>((resolve) => (releaseSend = resolve));
+
+    fetchMock.mockImplementation(async (...args: any[]) => {
+      const url = args[0] as string;
+      if (url === TOKEN_URL) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: "success", token: "ingest-token", expiresIn: 3600 }),
+        } as unknown as Response;
+      }
+      await sendInFlight;
+      return { ok: false, status: 503 } as unknown as Response;
+    });
+
+    for (let i = 0; i < 10_000; i++) metrics.logEvent(event());
+    const flushed = metrics.flushNow();
+
+    // The first batch is out of the queue and the request is hanging: refill the gap it left.
+    await vi.advanceTimersByTimeAsync(0);
+    for (let i = 0; i < 500; i++) metrics.logEvent(event());
+
+    releaseSend!();
+    await flushed;
+
+    // Nothing more is logged after this, so only the requeue path can hold the bound.
+    fetchMock.mockImplementation(async (...args: any[]) => {
+      const url = args[0] as string;
+      if (url === TOKEN_URL) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: "success", token: "ingest-token", expiresIn: 3600 }),
+        } as unknown as Response;
+      }
+      return { ok: true, status: 202 } as unknown as Response;
+    });
+    fetchMock.mockClear();
+    await metrics.flushNow();
+
+    const delivered = callsTo(fetchMock, INGEST_URL).reduce(
+      (total, call) => total + bodyOf(call).events.length,
+      0
+    );
+    expect(delivered).toBe(10_000);
+  });
+
   it("caps the backlog and splits it into batches", async () => {
     for (let i = 0; i < 10_050; i++) metrics.logEvent(event());
     await metrics.flushNow();

--- a/src/__tests__/metrics.test.ts
+++ b/src/__tests__/metrics.test.ts
@@ -1,0 +1,699 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LaraApiError, TimeoutError } from "@translated/lara";
+import * as z from "zod/v4";
+
+// Deliberately does NOT import utils/mocks.ts: its hoisted vi.mock("@translated/lara")
+// would replace the real error classes errorTypeFor is built around.
+vi.mock("#logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const URL_BASE = "http://localhost:8080";
+const TOKEN_URL = `${URL_BASE}/auth/issue-token`;
+const INGEST_URL = `${URL_BASE}/metrics/ingest-events`;
+
+type Metrics = typeof import("../metrics.js");
+
+/** Loads a fresh copy of the module: queue, token and installation id are module state. */
+async function loadMetrics(
+  env: Record<string, string | undefined> = {}
+): Promise<Metrics> {
+  // A home of its own per load, already carrying an installation id: only the
+  // tests that pass their own LARA_HOME care about the `install` event, and
+  // every other one would otherwise start with a stray one in the queue.
+  let home = env.LARA_HOME;
+  if (!("LARA_HOME" in env)) {
+    home = mkdtempSync(join(tmpdir(), "lara-metrics-"));
+    writeFileSync(join(home, "installation-id"), randomUUID());
+  }
+
+  const defaults: Record<string, string | undefined> = {
+    METRICS_URL: URL_BASE,
+    METRICS_API_KEY: "dev-mcp-key",
+    LARA_HOME: home,
+    DO_NOT_TRACK: undefined,
+    TRANSPORT: "stdio",
+  };
+
+  for (const [key, value] of Object.entries({ ...defaults, ...env })) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  vi.resetModules();
+  return import("../metrics.js");
+}
+
+function createFetchMock() {
+  // Loosely typed on purpose: the tests read back the RequestInit the module
+  // built, which the global fetch signature does not describe positionally.
+  return vi.fn(async (...args: any[]) => {
+    const url = args[0] as string;
+    if (url === TOKEN_URL) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success", token: "ingest-token", expiresIn: 3600 }),
+      } as unknown as Response;
+    }
+    return { ok: true, status: 202, json: async () => ({ status: "success", accepted: 1 }) } as unknown as Response;
+  });
+}
+
+const callsTo = (fetchMock: ReturnType<typeof createFetchMock>, url: string) =>
+  fetchMock.mock.calls.filter((call: any) => call[0] === url);
+
+const bodyOf = (call: any) => JSON.parse(call[1].body);
+
+/** A real 3-segment JWT whose payload is the given object. */
+function laraToken(payload: Record<string, unknown>): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `header.${encoded}.signature`;
+}
+
+const ACCOUNT = "acc_4kQpXbW2mNvRt7yZjD3sLh";
+
+/** A Translator stand-in exposing only the internal client field metrics reads. */
+const translatorWithToken = (token?: string) =>
+  ({ client: token === undefined ? {} : { token } }) as any;
+
+describe("accountIdFromToken", () => {
+  let metrics: Metrics;
+  beforeEach(async () => {
+    metrics = await loadMetrics();
+  });
+
+  it("reads the account from the id claim", () => {
+    const token = laraToken({
+      id: ACCOUNT,
+      userId: "usr_9fTb2xQnWkLmR4vPzE7cJd",
+      accessKey: { id: "AKID000000000000000000000" },
+    });
+
+    expect(metrics.accountIdFromToken(token)).toBe(ACCOUNT);
+  });
+
+  it("returns undefined when the payload carries no id", () => {
+    expect(metrics.accountIdFromToken(laraToken({ userId: "usr_1" }))).toBeUndefined();
+  });
+
+  it("returns undefined for something that is not a JWT", () => {
+    expect(metrics.accountIdFromToken("not-a-token")).toBeUndefined();
+    expect(metrics.accountIdFromToken("")).toBeUndefined();
+  });
+});
+
+describe("errorTypeFor", () => {
+  let metrics: Metrics;
+  let InvalidInputError: typeof import("../exception.js").InvalidInputError;
+
+  beforeEach(async () => {
+    metrics = await loadMetrics();
+    // Imported after the reset, so it is the very class metrics.ts holds:
+    // a stale copy from a previous module graph would fail every instanceof.
+    ({ InvalidInputError } = await import("../exception.js"));
+  });
+
+  it.each([
+    [new LaraApiError(401, "AuthenticationError", "nope"), "auth_401"],
+    [new LaraApiError(403, "Forbidden", "nope"), "auth_403"],
+    [new LaraApiError(429, "TooManyRequests", "slow down"), "rate_limit_429"],
+    [new LaraApiError(413, "PayloadTooLarge", "too big"), "payload_too_large"],
+    [new LaraApiError(500, "ServerError", "boom"), "server_error"],
+    [new LaraApiError(400, "BadRequest", "bad"), "validation_error"],
+    [new LaraApiError(200, "Weird", "?"), "unknown"],
+  ])("maps a Lara API error to its token", (error, expected) => {
+    expect(metrics.errorTypeFor(error)).toBe(expected);
+  });
+
+  it("maps an AuthenticationError with no usable status to auth_401", () => {
+    expect(metrics.errorTypeFor(new LaraApiError(0, "AuthenticationError", "nope"))).toBe(
+      "auth_401"
+    );
+  });
+
+  it("maps timeouts, validation and network failures", () => {
+    expect(metrics.errorTypeFor(new TimeoutError("slow"))).toBe("timeout");
+    expect(metrics.errorTypeFor(new InvalidInputError("bad field"))).toBe("validation_error");
+    // A tool's argument parse throws this, and it reaches errorTypeFor before
+    // CallTool has had a chance to rewrite it.
+    expect(metrics.errorTypeFor(z.string().safeParse(42).error)).toBe("validation_error");
+    expect(metrics.errorTypeFor({ name: "AbortError" })).toBe("timeout");
+    expect(metrics.errorTypeFor({ code: "ETIMEDOUT" })).toBe("timeout");
+    expect(metrics.errorTypeFor({ code: "ECONNREFUSED" })).toBe("network_error");
+    expect(metrics.errorTypeFor({ code: "ENOTFOUND" })).toBe("network_error");
+    expect(metrics.errorTypeFor(new Error("something else"))).toBe("unknown");
+    expect(metrics.errorTypeFor(null)).toBe("unknown");
+  });
+});
+
+describe("callFieldsFor", () => {
+  let metrics: Metrics;
+  beforeEach(async () => {
+    metrics = await loadMetrics();
+  });
+
+  it("names the capability, never the instance", () => {
+    expect(metrics.callFieldsFor("translate", {}).metadata.feature).toBe("text");
+    expect(metrics.callFieldsFor("detect_language", {}).metadata.feature).toBe(
+      "language_detection"
+    );
+    expect(metrics.callFieldsFor("list_memories", undefined).metadata.feature).toBe(
+      "resource_management"
+    );
+    expect(metrics.callFieldsFor("create_glossary", {}).metadata.feature).toBe(
+      "resource_management"
+    );
+  });
+
+  it("carries the transport and the tool name", () => {
+    const { metadata } = metrics.callFieldsFor("list_memories", undefined);
+    expect(metadata).toEqual({
+      transport: "stdio",
+      feature: "resource_management",
+      toolName: "list_memories",
+    });
+  });
+
+  it("lowercases the language tags and defaults the source to auto", () => {
+    const withSource = metrics.callFieldsFor("translate", {
+      source: "EN-US",
+      target: "IT-IT",
+      text: [],
+    });
+    expect(withSource.metadata.sourceLang).toBe("en-us");
+    expect(withSource.metadata.targetLang).toBe("it-it");
+
+    const detected = metrics.callFieldsFor("translate", { target: "it", text: [] });
+    expect(detected.metadata.sourceLang).toBe("auto");
+  });
+
+  it("counts only the blocks the engine actually translates", () => {
+    const { charsTranslated } = metrics.callFieldsFor("translate", {
+      target: "it",
+      text: [
+        { text: "hello" },
+        { text: "world", translatable: true },
+        { text: "verbatim block", translatable: false },
+      ],
+    });
+
+    expect(charsTranslated).toBe("hello".length + "world".length);
+  });
+
+  it("leaves charsTranslated out when the argument is not a block array", () => {
+    expect(metrics.callFieldsFor("translate", { target: "it" }).charsTranslated).toBeUndefined();
+    expect(metrics.callFieldsFor("list_memories", undefined).charsTranslated).toBeUndefined();
+  });
+});
+
+describe("installation id", () => {
+  let fetchMock: ReturnType<typeof createFetchMock>;
+
+  beforeEach(() => {
+    fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const idFile = (home: string) => join(home, "installation-id");
+
+  it("creates it on first run and reports install once", async () => {
+    const home = mkdtempSync(join(tmpdir(), "lara-metrics-"));
+
+    const first = await loadMetrics({ LARA_HOME: home });
+    await first.flushNow();
+
+    const stored = readFileSync(idFile(home), "utf8");
+    expect(stored).toMatch(/^[0-9a-f-]{36}$/);
+
+    const events = callsTo(fetchMock, INGEST_URL).flatMap((call) => bodyOf(call).events);
+    expect(events).toHaveLength(1);
+    expect(events[0].eventType).toBe("install");
+    expect(events[0].accountId).toBeUndefined();
+    expect(bodyOf(callsTo(fetchMock, TOKEN_URL)[0]).installationId).toBe(stored);
+
+    // A second start-up on the same home reuses the id and stays quiet.
+    fetchMock.mockClear();
+    const second = await loadMetrics({ LARA_HOME: home });
+    await second.flushNow();
+
+    expect(readFileSync(idFile(home), "utf8")).toBe(stored);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rewrites a corrupted id without reporting a new install", async () => {
+    const home = mkdtempSync(join(tmpdir(), "lara-metrics-"));
+    writeFileSync(idFile(home), "not-a-uuid");
+
+    const metrics = await loadMetrics({ LARA_HOME: home });
+    metrics.logEvent({ eventType: "auth_success", accountId: ACCOUNT });
+    await metrics.flushNow();
+
+    expect(readFileSync(idFile(home), "utf8")).toMatch(/^[0-9a-f-]{36}$/);
+    const events = callsTo(fetchMock, INGEST_URL).flatMap((call) => bodyOf(call).events);
+    expect(events.map((event: any) => event.eventType)).toEqual(["auth_success"]);
+  });
+
+  it("keeps reporting with a per-process id when the home is not writable", async () => {
+    // A path whose parent is a file, so mkdir cannot create it.
+    const blocker = join(mkdtempSync(join(tmpdir(), "lara-metrics-")), "blocker");
+    writeFileSync(blocker, "");
+
+    const metrics = await loadMetrics({ LARA_HOME: join(blocker, "home") });
+    metrics.logEvent({ eventType: "auth_success", accountId: ACCOUNT });
+    await metrics.flushNow();
+
+    const installationId = bodyOf(callsTo(fetchMock, TOKEN_URL)[0]).installationId;
+    expect(installationId).toMatch(/^[0-9a-f-]{36}$/);
+    // No install event: nothing was installed, the id simply could not be stored.
+    const events = callsTo(fetchMock, INGEST_URL).flatMap((call) => bodyOf(call).events);
+    expect(events.map((event: any) => event.eventType)).toEqual(["auth_success"]);
+  });
+});
+
+describe("delivery", () => {
+  let fetchMock: ReturnType<typeof createFetchMock>;
+  let metrics: Metrics;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    metrics = await loadMetrics();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  const event = (overrides: Partial<Parameters<Metrics["logEvent"]>[0]> = {}) => ({
+    eventType: "call_success" as const,
+    accountId: ACCOUNT,
+    ...overrides,
+  });
+
+  it("buys a token with the API key and sends events with the token", async () => {
+    metrics.logEvent(event());
+    await metrics.flushNow();
+
+    const tokenCall = callsTo(fetchMock, TOKEN_URL)[0];
+    expect(tokenCall[1].headers.Authorization).toBe("Bearer dev-mcp-key");
+    expect(tokenCall[1].signal).toBeDefined();
+
+    const ingestCall = callsTo(fetchMock, INGEST_URL)[0];
+    expect(ingestCall[1].headers.Authorization).toBe("Bearer ingest-token");
+    expect(bodyOf(ingestCall).events[0]).toMatchObject({
+      eventType: "call_success",
+      accountId: ACCOUNT,
+      channel: "mcp",
+    });
+  });
+
+  it("stamps the envelope on every event", async () => {
+    metrics.logEvent(event());
+    await metrics.flushNow();
+
+    const [sent] = bodyOf(callsTo(fetchMock, INGEST_URL)[0]).events;
+    expect(sent.channelVersion).toEqual(expect.any(String));
+    expect(sent.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(sent.eventId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(Date.parse(sent.timestamp)).not.toBeNaN();
+  });
+
+  it("batches everything queued into one request", async () => {
+    metrics.logEvent(event());
+    metrics.logEvent(event());
+    metrics.logEvent(event({ eventType: "call_error", errorType: "timeout" }));
+    await metrics.flushNow();
+
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(1);
+    expect(bodyOf(callsTo(fetchMock, INGEST_URL)[0]).events).toHaveLength(3);
+  });
+
+  it("flushes on its own timer", async () => {
+    metrics.logEvent(event());
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await metrics.flushNow();
+
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(1);
+  });
+
+  it("reuses the token across flushes", async () => {
+    metrics.logEvent(event());
+    await metrics.flushNow();
+    metrics.logEvent(event());
+    await metrics.flushNow();
+
+    expect(callsTo(fetchMock, TOKEN_URL)).toHaveLength(1);
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(2);
+  });
+
+  it("re-issues the token and retries exactly once on 401", async () => {
+    let ingestCalls = 0;
+    fetchMock.mockImplementation(async (...args: any[]) => {
+      const url = args[0] as string;
+      if (url === TOKEN_URL) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: "success", token: `token-${++tokenSerial}`, expiresIn: 3600 }),
+        } as unknown as Response;
+      }
+      ingestCalls += 1;
+      if (ingestCalls === 1) return { ok: false, status: 401 } as unknown as Response;
+      return { ok: true, status: 202 } as unknown as Response;
+    });
+    let tokenSerial = 0;
+
+    metrics.logEvent(event());
+    await metrics.flushNow();
+
+    const ingest = callsTo(fetchMock, INGEST_URL);
+    expect(ingest).toHaveLength(2);
+    expect(ingest[0][1].headers.Authorization).toBe("Bearer token-1");
+    expect(ingest[1][1].headers.Authorization).toBe("Bearer token-2");
+    // The retry carries the same eventId, so the backend can recognize the duplicate.
+    expect(bodyOf(ingest[1]).events[0].eventId).toBe(bodyOf(ingest[0]).events[0].eventId);
+  });
+
+  it("gives up after a single retry", async () => {
+    let tokenSerial = 0;
+    fetchMock.mockImplementation(async (...args: any[]) => {
+      const url = args[0] as string;
+      if (url === TOKEN_URL) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: "success", token: `token-${++tokenSerial}`, expiresIn: 3600 }),
+        } as unknown as Response;
+      }
+      return { ok: false, status: 401 } as unknown as Response;
+    });
+
+    metrics.logEvent(event());
+    await metrics.flushNow();
+
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(2);
+  });
+
+  it("requeues a batch the backend could not take, and drops one it rejected", async () => {
+    fetchMock.mockImplementation(async (...args: any[]) => {
+      const url = args[0] as string;
+      if (url === TOKEN_URL) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: "success", token: "ingest-token", expiresIn: 3600 }),
+        } as unknown as Response;
+      }
+      return { ok: false, status: 429 } as unknown as Response;
+    });
+
+    metrics.logEvent(event());
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(1);
+
+    // Still queued: the next flush sends it again.
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(2);
+
+    // A verdict from the backend is different — the same body would be refused forever.
+    fetchMock.mockImplementation(async (...args: any[]) => {
+      const url = args[0] as string;
+      if (url === TOKEN_URL) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: "success", token: "ingest-token", expiresIn: 3600 }),
+        } as unknown as Response;
+      }
+      return { ok: false, status: 400 } as unknown as Response;
+    });
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(3);
+
+    // Dropped, so there is nothing left for the next flush to send.
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(3);
+  });
+
+  it("holds the batch back while the token endpoint is in cooldown", async () => {
+    fetchMock.mockImplementationOnce(async () => ({ ok: false, status: 429 }) as unknown as Response);
+
+    metrics.logEvent(event());
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, TOKEN_URL)).toHaveLength(1);
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(0);
+
+    // Inside the 10s window the endpoint is not even asked.
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, TOKEN_URL)).toHaveLength(1);
+
+    vi.advanceTimersByTime(10_000);
+    await metrics.flushNow();
+    expect(callsTo(fetchMock, TOKEN_URL)).toHaveLength(2);
+    expect(bodyOf(callsTo(fetchMock, INGEST_URL)[0]).events).toHaveLength(1);
+  });
+
+  it("caps the backlog and splits it into batches", async () => {
+    for (let i = 0; i < 10_050; i++) metrics.logEvent(event());
+    await metrics.flushNow();
+
+    const batches = callsTo(fetchMock, INGEST_URL).map((call) => bodyOf(call).events.length);
+    expect(Math.max(...batches)).toBeLessThanOrEqual(500);
+    expect(batches.reduce((a, b) => a + b, 0)).toBe(10_000);
+  });
+
+  it("swallows a backend that rejects outright", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    metrics.logEvent(event());
+    await expect(metrics.flushNow()).resolves.toBeUndefined();
+  });
+
+  it("never sends credentials or translated text", async () => {
+    metrics.logEvent({
+      eventType: "call_success",
+      accountId: ACCOUNT,
+      ...metrics.callFieldsFor("translate", {
+        source: "en",
+        target: "it",
+        text: [{ text: "a very secret sentence" }],
+      }),
+    });
+    await metrics.flushNow();
+
+    const payload = JSON.stringify(bodyOf(callsTo(fetchMock, INGEST_URL)[0]));
+    expect(payload).not.toContain("a very secret sentence");
+    expect(payload).not.toContain("dev-mcp-key");
+    expect(payload).not.toContain("accessKey");
+  });
+});
+
+describe("opt-out and configuration", () => {
+  let fetchMock: ReturnType<typeof createFetchMock>;
+
+  beforeEach(() => {
+    fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each(["1", "true", "yes", "TRUE", " 1 "])(
+    "sends nothing when DO_NOT_TRACK is %s",
+    async (value) => {
+      const metrics = await loadMetrics({ DO_NOT_TRACK: value });
+
+      expect(metrics.metricsEnabled()).toBe(false);
+      metrics.logEvent({ eventType: "call_success", accountId: ACCOUNT });
+      await metrics.flushNow();
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("stays on for a DO_NOT_TRACK value that is not an opt-out", async () => {
+    const metrics = await loadMetrics({ DO_NOT_TRACK: "0" });
+    expect(metrics.metricsEnabled()).toBe(true);
+  });
+
+  it("writes no installation id when telemetry is off", async () => {
+    const home = mkdtempSync(join(tmpdir(), "lara-metrics-"));
+    await loadMetrics({ DO_NOT_TRACK: "1", LARA_HOME: home });
+
+    expect(() => readFileSync(join(home, "installation-id"), "utf8")).toThrow();
+  });
+
+  it.each([
+    ["an unset URL", { METRICS_URL: undefined }],
+    ["an unset API key", { METRICS_API_KEY: undefined }],
+    ["a blank API key", { METRICS_API_KEY: "   " }],
+    ["a malformed URL", { METRICS_URL: "not a url" }],
+  ])("is off with %s", async (_label, env) => {
+    const metrics = await loadMetrics(env);
+
+    expect(metrics.metricsEnabled()).toBe(false);
+    metrics.logEvent({ eventType: "call_success", accountId: ACCOUNT });
+    await metrics.flushNow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a trailing slash on the URL", async () => {
+    const metrics = await loadMetrics({ METRICS_URL: `${URL_BASE}//` });
+    metrics.logEvent({ eventType: "call_success", accountId: ACCOUNT });
+    await metrics.flushNow();
+
+    expect(callsTo(fetchMock, TOKEN_URL)).toHaveLength(1);
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(1);
+  });
+
+  it("builds no context when telemetry is off", async () => {
+    const metrics = await loadMetrics({ DO_NOT_TRACK: "1" });
+    expect(metrics.createMetricsContext(translatorWithToken(laraToken({ id: ACCOUNT })))).toBeUndefined();
+  });
+});
+
+describe("reporting a tool call", () => {
+  let fetchMock: ReturnType<typeof createFetchMock>;
+  let metrics: Metrics;
+
+  const sentEvents = () =>
+    callsTo(fetchMock, INGEST_URL).flatMap((call) => bodyOf(call).events);
+
+  beforeEach(async () => {
+    fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    metrics = await loadMetrics();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports auth_success once, then a call_success per call", async () => {
+    const ctx = metrics.createMetricsContext(translatorWithToken(laraToken({ id: ACCOUNT })))!;
+
+    metrics.reportCallSuccess(ctx, "translate", { target: "it", text: [{ text: "ciao" }] }, Date.now());
+    metrics.reportCallSuccess(ctx, "list_memories", undefined, Date.now());
+    await metrics.flushNow();
+
+    const events = sentEvents();
+    expect(events.map((e: any) => e.eventType)).toEqual([
+      "auth_success",
+      "call_success",
+      "call_success",
+    ]);
+    expect(events.every((e: any) => e.accountId === ACCOUNT)).toBe(true);
+    expect(events[1]).toMatchObject({
+      charsTranslated: 4,
+      metadata: { feature: "text", toolName: "translate", targetLang: "it", transport: "stdio" },
+    });
+    expect(events[1].latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports auth_success once per account across sessions", async () => {
+    const token = laraToken({ id: ACCOUNT });
+    // Two sessions for the same account: the HTTP transport builds one per request.
+    metrics.reportCallSuccess(
+      metrics.createMetricsContext(translatorWithToken(token))!,
+      "list_memories",
+      undefined,
+      Date.now()
+    );
+    metrics.reportCallSuccess(
+      metrics.createMetricsContext(translatorWithToken(token))!,
+      "list_memories",
+      undefined,
+      Date.now()
+    );
+    await metrics.flushNow();
+
+    expect(sentEvents().filter((e: any) => e.eventType === "auth_success")).toHaveLength(1);
+  });
+
+  it("reports auth_success per distinct account", async () => {
+    for (const id of [ACCOUNT, "acc_other"]) {
+      metrics.reportCallSuccess(
+        metrics.createMetricsContext(translatorWithToken(laraToken({ id })))!,
+        "list_memories",
+        undefined,
+        Date.now()
+      );
+    }
+    await metrics.flushNow();
+
+    const authEvents = sentEvents().filter((e: any) => e.eventType === "auth_success");
+    expect(authEvents.map((e: any) => e.accountId)).toEqual([ACCOUNT, "acc_other"]);
+  });
+
+  it("reports call_error, and auth_fail beside it when Lara rejected the key", async () => {
+    const ctx = metrics.createMetricsContext(translatorWithToken(laraToken({ id: ACCOUNT })))!;
+    ctx.accountId = ACCOUNT;
+
+    metrics.reportCallError(
+      ctx,
+      "translate",
+      { target: "it", text: [] },
+      Date.now(),
+      new LaraApiError(401, "AuthenticationError", "nope")
+    );
+    metrics.reportCallError(ctx, "translate", {}, Date.now(), new TimeoutError("slow"));
+    await metrics.flushNow();
+
+    const events = sentEvents();
+    expect(events.map((e: any) => e.eventType)).toEqual([
+      "call_error",
+      "auth_fail",
+      "call_error",
+    ]);
+    expect(events[0].errorType).toBe("auth_401");
+    expect(events[2].errorType).toBe("timeout");
+    expect(events[2].latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports nothing for a key the SDK never exchanged", async () => {
+    const ctx = metrics.createMetricsContext(translatorWithToken(undefined))!;
+
+    metrics.reportCallSuccess(ctx, "translate", {}, Date.now());
+    metrics.reportCallError(ctx, "translate", {}, Date.now(), new LaraApiError(401, "AuthenticationError", "nope"));
+    await metrics.flushNow();
+
+    expect(callsTo(fetchMock, INGEST_URL)).toHaveLength(0);
+  });
+
+  it("is a no-op without a context", async () => {
+    metrics.reportCallSuccess(undefined, "translate", {}, Date.now());
+    metrics.reportCallError(undefined, "translate", {}, Date.now(), new Error("boom"));
+    await metrics.flushNow();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("decodes the account once and caches it on the context", async () => {
+    const translator = translatorWithToken(laraToken({ id: ACCOUNT }));
+    const ctx = metrics.createMetricsContext(translator)!;
+
+    metrics.reportCallSuccess(ctx, "list_memories", undefined, Date.now());
+    expect(ctx.accountId).toBe(ACCOUNT);
+
+    // The token is gone, but the account is already known.
+    translator.client.token = undefined;
+    metrics.reportCallSuccess(ctx, "list_memories", undefined, Date.now());
+    await metrics.flushNow();
+
+    expect(sentEvents().filter((e: any) => e.eventType === "call_success")).toHaveLength(2);
+  });
+});

--- a/src/__tests__/server/mcp.metrics.test.ts
+++ b/src/__tests__/server/mcp.metrics.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+vi.mock("#logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Only the Translator is faked. The error classes stay real: errorTypeFor is
+// built on instanceof, and a stubbed LaraApiError would make every mapping pass
+// for the wrong reason.
+const { translators } = vi.hoisted(() => ({ translators: [] as any[] }));
+
+vi.mock("@translated/lara", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@translated/lara")>();
+  return {
+    ...actual,
+    Translator: vi.fn(() => {
+      const instance = {
+        client: { setExtraHeader: vi.fn(), token: (globalThis as any).__laraToken },
+        translate: vi.fn(),
+        memories: { list: vi.fn().mockResolvedValue([]) },
+      };
+      translators.push(instance);
+      return instance;
+    }),
+  };
+});
+
+// The MCP SDK Server is replaced by a handler registry, so the test can invoke
+// the very handler getMcpServer registered.
+const { handlers } = vi.hoisted(() => ({ handlers: new Map<unknown, any>() }));
+
+vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
+  Server: vi.fn(() => ({
+    setRequestHandler: (schema: unknown, handler: any) => handlers.set(schema, handler),
+  })),
+}));
+
+const URL_BASE = "http://localhost:8080";
+const INGEST_URL = `${URL_BASE}/metrics/ingest-events`;
+const ACCOUNT = "acc_4kQpXbW2mNvRt7yZjD3sLh";
+
+const laraToken = (payload: Record<string, unknown>) =>
+  `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+
+function createFetchMock() {
+  // Loosely typed on purpose: the tests read back the RequestInit the module
+  // built, which the global fetch signature does not describe positionally.
+  return vi.fn(async (...args: any[]) => {
+    const url = args[0] as string;
+    if (url.endsWith("/auth/issue-token")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success", token: "ingest-token", expiresIn: 3600 }),
+      } as unknown as Response;
+    }
+    return { ok: true, status: 202 } as unknown as Response;
+  });
+}
+
+let fetchMock: ReturnType<typeof createFetchMock>;
+
+async function loadServer(env: Record<string, string> = {}) {
+  const home = mkdtempSync(join(tmpdir(), "lara-server-metrics-"));
+  // Seeded, so the install event is not in the way of what each test asserts.
+  writeFileSync(join(home, "installation-id"), randomUUID());
+
+  delete process.env.DO_NOT_TRACK;
+  Object.assign(process.env, {
+    METRICS_URL: URL_BASE,
+    METRICS_API_KEY: "dev-mcp-key",
+    LARA_HOME: home,
+    TRANSPORT: "stdio",
+    ...env,
+  });
+
+  vi.resetModules();
+  handlers.clear();
+  translators.length = 0;
+
+  const { default: getMcpServer } = await import("../../mcp/server.js");
+  const metrics = await import("../../metrics.js");
+  return { getMcpServer, metrics };
+}
+
+const callTool = (name: string, args?: unknown) =>
+  handlers.get(CallToolRequestSchema)({
+    method: "tools/call",
+    params: { name, arguments: args },
+  });
+
+const sentEvents = () =>
+  fetchMock.mock.calls
+    .filter((call: any) => call[0] === INGEST_URL)
+    .flatMap((call) => JSON.parse((call[1] as any).body).events);
+
+beforeEach(() => {
+  fetchMock = createFetchMock();
+  vi.stubGlobal("fetch", fetchMock);
+  (globalThis as any).__laraToken = laraToken({ id: ACCOUNT });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete (globalThis as any).__laraToken;
+});
+
+describe("getMcpServer funnel metrics", () => {
+  it("reports auth_success then a call_success per tool call", async () => {
+    const { getMcpServer, metrics } = await loadServer();
+    getMcpServer("key-id", "key-secret");
+
+    await callTool("list_memories");
+    await callTool("list_memories");
+    await metrics.flushNow();
+
+    const events = sentEvents();
+    expect(events.map((event: any) => event.eventType)).toEqual([
+      "auth_success",
+      "call_success",
+      "call_success",
+    ]);
+    // The account behind the key, never the key itself.
+    expect(events.every((event: any) => event.accountId === ACCOUNT)).toBe(true);
+    const payload = JSON.stringify(events);
+    expect(payload).not.toContain("key-id");
+    expect(payload).not.toContain("key-secret");
+  });
+
+  it("reports auth_success once per account across server instances", async () => {
+    const { getMcpServer, metrics } = await loadServer({ TRANSPORT: "http" });
+
+    // The HTTP transport is stateless: one server, and one Translator, per request.
+    getMcpServer("key-id", "key-secret");
+    await callTool("list_memories");
+    getMcpServer("key-id", "key-secret");
+    await callTool("list_memories");
+    await metrics.flushNow();
+
+    const events = sentEvents();
+    expect(events.filter((event: any) => event.eventType === "auth_success")).toHaveLength(1);
+    expect(events[1].metadata.transport).toBe("http");
+  });
+
+  it("describes a translate call with feature, languages and character count", async () => {
+    const { getMcpServer, metrics } = await loadServer();
+    getMcpServer("key-id", "key-secret");
+
+    translators[0].translate.mockResolvedValue({ translation: [{ text: "ciao" }] });
+    await callTool("translate", {
+      source: "EN-US",
+      target: "IT-IT",
+      text: [{ text: "hello" }, { text: "keep me", translatable: false }],
+    });
+    await metrics.flushNow();
+
+    const call = sentEvents().find((event: any) => event.eventType === "call_success");
+    expect(call).toMatchObject({
+      charsTranslated: 5,
+      metadata: {
+        feature: "text",
+        toolName: "translate",
+        sourceLang: "en-us",
+        targetLang: "it-it",
+        transport: "stdio",
+      },
+    });
+    expect(call.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports auth_fail beside call_error even though CallTool rewrites the error", async () => {
+    const { getMcpServer, metrics } = await loadServer();
+    const { LaraApiError } = await import("@translated/lara");
+    getMcpServer("key-id", "key-secret");
+
+    translators[0].translate.mockRejectedValue(
+      new LaraApiError(401, "AuthenticationError", "invalid credentials")
+    );
+
+    await expect(
+      callTool("translate", { target: "it", text: [{ text: "hello" }] })
+    ).rejects.toThrow("invalid credentials");
+    await metrics.flushNow();
+
+    const events = sentEvents();
+    expect(events.map((event: any) => event.eventType)).toEqual(["call_error", "auth_fail"]);
+    expect(events[0].errorType).toBe("auth_401");
+    expect(events[0].latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports a validation failure as call_error without auth_fail", async () => {
+    const { getMcpServer, metrics } = await loadServer();
+    getMcpServer("key-id", "key-secret");
+
+    await expect(callTool("translate", { target: 42 })).rejects.toThrow();
+    await metrics.flushNow();
+
+    const events = sentEvents();
+    expect(events.map((event: any) => event.eventType)).toEqual(["call_error"]);
+    expect(events[0].errorType).toBe("validation_error");
+  });
+
+  it("reports nothing when the SDK never exchanged the key for a token", async () => {
+    (globalThis as any).__laraToken = undefined;
+    const { getMcpServer, metrics } = await loadServer();
+    getMcpServer("bad-id", "bad-secret");
+
+    await callTool("list_memories");
+    await metrics.flushNow();
+
+    expect(sentEvents()).toHaveLength(0);
+  });
+
+  it("does no reporting at all when telemetry is opted out of", async () => {
+    const { getMcpServer, metrics } = await loadServer({ DO_NOT_TRACK: "1" });
+    getMcpServer("key-id", "key-secret");
+
+    await callTool("list_memories");
+    await metrics.flushNow();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the tool result untouched", async () => {
+    const { getMcpServer } = await loadServer();
+    getMcpServer("key-id", "key-secret");
+
+    translators[0].memories.list.mockResolvedValue([{ id: "mem_1" }]);
+    const result = await callTool("list_memories");
+
+    expect(result.structuredContent).toEqual({ items: [{ id: "mem_1" }] });
+  });
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -14,6 +14,20 @@ const envSchema = z.object({
     // Lara STDIO MCP Server
     LARA_ACCESS_KEY_ID: z.string().optional(),
     LARA_ACCESS_KEY_SECRET: z.string().optional(),
+
+    // Funnel metrics (integrations monitoring backend, channel "mcp").
+    // These override the defaults compiled into src/metrics.ts; both are plain
+    // strings rather than z.url() because this schema is parsed at import time
+    // and a malformed value in a published package must not crash the user's
+    // server — metrics.ts validates the URL and turns telemetry off instead.
+    METRICS_URL: z.string().optional(),
+    METRICS_API_KEY: z.string().optional(),
+
+    // Where product state lives (the metrics installation id). Default: ~/.lara
+    LARA_HOME: z.string().optional(),
+
+    // https://consoledonottrack.com — 1/true/yes disables every event.
+    DO_NOT_TRACK: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import mcpRouter from "./rest/routes/mcp.js";
 import serverInfoRouter from "./rest/routes/server-info.js";
 import { RestServer } from "./rest/server.js";
 import { logger } from "./logger.js";
+import { flushNow } from "./metrics.js";
 import { Server as McpServer } from "@modelcontextprotocol/sdk/server/index.js";
 
 // -- Start server
@@ -24,17 +25,26 @@ switch (env.TRANSPORT) {
     throw new Error("Invalid transport: " + env.TRANSPORT + ". Must be either 'stdio' or 'http'");
 }
 
-process.on("SIGINT", () => signalHandler(server));
-process.on("SIGTERM", () => signalHandler(server));
-process.on("SIGQUIT", () => signalHandler(server));
+process.on("SIGINT", () => void signalHandler(server));
+process.on("SIGTERM", () => void signalHandler(server));
+process.on("SIGQUIT", () => void signalHandler(server));
 
 // -- Signal handler
-function signalHandler(server: RestServer | McpServer) {
+async function signalHandler(server: RestServer | McpServer) {
   if (server instanceof RestServer) {
     server.stop();
   } else {
     server.close();
   }
+
+  // Deliver the queued metrics before the process goes: batched events are held
+  // in memory behind an unref'd timer, so without this the last batch dies with
+  // it. Capped, because draining a long backlog would eat a shutdown budget the
+  // supervisor ends with a SIGKILL anyway.
+  await Promise.race([
+    flushNow(),
+    new Promise((resolve) => setTimeout(resolve, 2000)),
+  ]);
 
   process.exit(0);
 }

--- a/src/lara-client.ts
+++ b/src/lara-client.ts
@@ -1,0 +1,35 @@
+import type { Translator } from "@translated/lara";
+import { logger } from "#logger";
+
+/**
+ * The subset of the SDK's internal LaraClient this server depends on.
+ * `Translator.client` is `protected` in the type declarations only; everything
+ * below reaches it through the single cast in getLaraClient().
+ */
+export interface LaraClientShape {
+  /**
+   * The Lara access token the SDK holds: the result of its own /v2/auth
+   * exchange of the access key. Populated lazily, on the first request.
+   */
+  token?: string;
+  setExtraHeader?: (name: string, value: string) => void;
+}
+
+/**
+ * Single guarded accessor for the Translator's internal LaraClient — the only
+ * place that casts through `protected`. Callers check the specific capability
+ * they need; this centralizes the cast and the "client itself is gone"
+ * detection so an SDK change surfaces in one spot.
+ */
+export function getLaraClient(
+  translator: Translator
+): LaraClientShape | undefined {
+  const client = (translator as unknown as { client?: unknown }).client;
+  if (!client || typeof client !== "object") {
+    logger.warn(
+      "Translator.client is no longer accessible. Check for Lara SDK updates."
+    );
+    return undefined;
+  }
+  return client as LaraClientShape;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,8 @@ import {
 import { CallTool, ListTools } from "./tools.js";
 import { ListResources, ListResourceTemplates, ReadResource } from "./resources.js";
 import { logger } from "#logger";
+import { getLaraClient } from "../lara-client.js";
+import { createMetricsContext } from "../metrics.js";
 import { PACKAGE_VERSION } from "../version.js";
 
 export default function getMcpServer(
@@ -24,10 +26,8 @@ export default function getMcpServer(
   // Identify MCP-originated traffic to Lara on every SDK request. extraHeaders
   // are spread into all requests by the SDK transport, so setting them once
   // here covers translate, glossaries, memories, languages, imports, etc. The
-  // client is protected/internal in the SDK types, hence the narrow cast.
-  const laraClient = (lara as unknown as {
-    client?: { setExtraHeader?: (name: string, value: string) => void };
-  }).client;
+  // client is protected/internal in the SDK types, hence the guarded accessor.
+  const laraClient = getLaraClient(lara);
   if (typeof laraClient?.setExtraHeader === "function") {
     laraClient.setExtraHeader("X-Lara-Client", "MCP");
     laraClient.setExtraHeader("X-Lara-Client-Version", PACKAGE_VERSION);
@@ -52,9 +52,13 @@ export default function getMcpServer(
   logger.debug("MCP server created! Setting request handlers...");
 
   // -- Tools
+  // Funnel telemetry for this session. Undefined when metrics are off or opted
+  // out of, which makes every report inside CallTool a no-op.
+  const metrics = createMetricsContext(lara);
+
   server.setRequestHandler(ListToolsRequestSchema, ListTools);
   server.setRequestHandler(CallToolRequestSchema, (request) =>
-    CallTool(request, lara)
+    CallTool(request, lara, metrics)
   );
 
   // -- Resources

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -117,6 +117,11 @@ import {
 } from "./tools/update_memory.tool.js";
 import { InvalidInputError } from "#exception";
 import { logger } from "#logger";
+import {
+  type MetricsContext,
+  reportCallError,
+  reportCallSuccess,
+} from "../metrics.js";
 
 type Handler = (args: any, lara: Translator) => Promise<any>;
 type Lister = (lara: Translator) => Promise<any>;
@@ -223,9 +228,11 @@ function narrate(name: string, args: any, result: any): string {
 
 async function CallTool(
   request: CallToolRequest,
-  lara: Translator
+  lara: Translator,
+  metrics?: MetricsContext
 ): Promise<CallToolResult> {
   const { name, arguments: args } = request.params;
+  const startedAt = Date.now();
 
   logger.debug({ toolName: name }, "Tool called");
 
@@ -240,6 +247,11 @@ async function CallTool(
       throw new InvalidInputError(`Tool ${name} not found`);
     }
 
+    // Reported from inside the try, not from a wrapper around this function:
+    // the catch below rewrites the SDK's errors, so only here is the original
+    // still in hand. Fire-and-forget — it never delays or alters the result.
+    reportCallSuccess(metrics, name, args, startedAt);
+
     const structuredContent = toStructuredContent(result);
     return {
       structuredContent,
@@ -253,6 +265,8 @@ async function CallTool(
       ],
     };
   } catch (error) {
+    reportCallError(metrics, name, args, startedAt, error);
+
     if (error instanceof z.ZodError) {
       const fieldErrors = error.issues
         .map(i => {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,510 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { LaraApiError, TimeoutError, type Translator } from "@translated/lara";
+import * as z from "zod/v4";
+
+import { env } from "#env";
+import { InvalidInputError } from "#exception";
+import { logger } from "#logger";
+import { getLaraClient } from "./lara-client.js";
+import { PACKAGE_VERSION } from "./version.js";
+
+/**
+ * Where the funnel events go. Empty until the integrations monitoring backend
+ * is deployed and a production key is issued for the `mcp` channel: with either
+ * one missing telemetry is silently off, which is the intended fallback rather
+ * than a failure. METRICS_URL / METRICS_API_KEY override both.
+ */
+const DEFAULT_METRICS_URL = "";
+const DEFAULT_METRICS_API_KEY = "";
+
+const REQUEST_TIMEOUT_MS = 3000;
+/** A minute of slack, so a token never expires mid-flight. */
+const TOKEN_MARGIN_MS = 60_000;
+/** The token endpoint issues one per 10s per installation. */
+const TOKEN_COOLDOWN_MS = 10_000;
+/** Ingest allows 100 requests/min per installation; one flush every 2s stays far under it. */
+const FLUSH_INTERVAL_MS = 2000;
+/** The backend accepts 1000 events per batch. */
+const MAX_BATCH = 500;
+/** A backlog means the backend is unreachable; past this the oldest events are dropped. */
+const MAX_QUEUE = 10_000;
+/**
+ * Accounts remembered for the auth_success dedup below. One HTTP process serves
+ * many accounts, so the set has to be bounded; re-reporting an auth_success
+ * after a reset costs nothing, since no event needs a "have I sent this" flag.
+ */
+const MAX_SEEN_ACCOUNTS = 1000;
+
+const INSTALLATION_FILE = "installation-id";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The backend rejects a malformed URL with a crash we would be handing to the
+ * user, so an unusable value turns telemetry off instead.
+ */
+function normalizeUrl(value: string): string | undefined {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) return undefined;
+
+  try {
+    new URL(trimmed);
+    return trimmed;
+  } catch {
+    logger.warn("METRICS_URL is not a valid URL; funnel metrics are disabled");
+    return undefined;
+  }
+}
+
+// Constant for the process lifetime, so they are built once rather than per event.
+const BASE_URL = normalizeUrl(env.METRICS_URL ?? DEFAULT_METRICS_URL);
+const API_KEY = (env.METRICS_API_KEY ?? DEFAULT_METRICS_API_KEY).trim();
+const TOKEN_URL = `${BASE_URL}/auth/issue-token`;
+const INGEST_URL = `${BASE_URL}/metrics/ingest-events`;
+
+/**
+ * Groups everything one running server process does, so a burst of retries can be told apart
+ * from recurring use. It identifies the process, NOT the user — that is what accountId is for.
+ */
+const SESSION_ID = randomUUID();
+
+/** The part of every event that is fixed for the life of the process. */
+const ENVELOPE = { channel: "mcp", channelVersion: PACKAGE_VERSION, sessionId: SESSION_ID };
+
+/**
+ * Which transport emitted the event. Both report the same way, and telling them
+ * apart is the whole point of instrumenting both.
+ */
+const BASE_METADATA = { transport: env.TRANSPORT };
+
+export type MetricsEvent = {
+  eventType: "install" | "auth_success" | "auth_fail" | "call_success" | "call_error";
+  /** Absent only on `install` and `auth_fail`, the two the backend lets omit it. */
+  accountId?: string;
+  errorType?: string;
+  latencyMs?: number;
+  charsTranslated?: number;
+  metadata?: Record<string, unknown>;
+};
+
+type QueuedEvent = MetricsEvent & {
+  channel: string;
+  channelVersion: string;
+  sessionId: string;
+  eventId: string;
+  timestamp: string;
+};
+
+/** Opt-out, honoured before anything is measured, queued or written to disk. */
+const doNotTrack = (): boolean =>
+  ["1", "true", "yes"].includes((env.DO_NOT_TRACK ?? "").trim().toLowerCase());
+
+/**
+ * Telemetry is on. Unconfigured = silently off, which is the intended fallback rather than a
+ * failure. Both transports report: unlike the private server there is no store to depend on.
+ */
+export const metricsEnabled = (): boolean =>
+  Boolean(BASE_URL && API_KEY) && !doNotTrack();
+
+/**
+ * What a tool call exercises, from the shared vocabulary every Lara integration reports against.
+ * It names a capability, never an instance, and the values are stable forever: renaming one
+ * silently splits its history in the dashboards.
+ */
+const FEATURE_BY_TOOL = {
+  translate: "text",
+  detect_language: "language_detection",
+} as const;
+
+const featureFor = (toolName: string): string =>
+  FEATURE_BY_TOOL[toolName as keyof typeof FEATURE_BY_TOOL] ?? "resource_management";
+
+/**
+ * The backend fields one tool call produces. It lives here with the rest of the reporting
+ * vocabulary: `feature`, the language tags and the character count are all facts about how a
+ * tool's arguments map onto the funnel, and they change together.
+ *
+ * The arguments are unvalidated — the tool handler is what parses them, and on the error path the
+ * parse is exactly what failed — so every field is checked before use.
+ */
+export function callFieldsFor(
+  toolName: string,
+  args: unknown
+): { metadata: Record<string, unknown>; charsTranslated?: number } {
+  const metadata: Record<string, unknown> = {
+    ...BASE_METADATA,
+    feature: featureFor(toolName),
+    toolName,
+  };
+  if (toolName !== "translate") return { metadata };
+
+  const { source, target, text } = (args ?? {}) as {
+    source?: unknown;
+    target?: unknown;
+    text?: unknown;
+  };
+  // Lowercase BCP 47, and `auto` is what the engine actually does when no source is given.
+  metadata.sourceLang = typeof source === "string" ? source.toLowerCase() : "auto";
+  if (typeof target === "string") metadata.targetLang = target.toLowerCase();
+
+  return { metadata, charsTranslated: charsTranslatedIn(text) };
+}
+
+/**
+ * Characters a translate call actually sends to the engine: blocks flagged `translatable: false`
+ * (see textBlockSchema in mcp/tools/_schemas.ts) are preserved verbatim, so counting them would
+ * overstate usage.
+ */
+function charsTranslatedIn(blocks: unknown): number | undefined {
+  if (!Array.isArray(blocks)) return undefined;
+
+  let total = 0;
+  for (const block of blocks) {
+    const { text, translatable } = (block ?? {}) as { text?: unknown; translatable?: unknown };
+    if (typeof text === "string" && translatable !== false) total += text.length;
+  }
+  return total;
+}
+
+function postJson(url: string, bearer: string, body: unknown): Promise<Response> {
+  return fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${bearer}`, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    // Without a timeout a fire-and-forget POST to an unresponsive backend holds the socket open.
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}
+
+type Installation = { id: string; created: boolean };
+
+/**
+ * The installation this copy of the server reports as. A UUID generated once and kept next to the
+ * rest of the product's state, so every restart and every upgrade share it: the backend's rate
+ * limits are counted per installation, and a fresh one per start-up would make them meaningless.
+ *
+ * Resolved synchronously and once. It has to be, to know whether the id is new — which is what
+ * decides the `install` event — and readFileSync at module load already has a precedent in
+ * version.ts.
+ */
+let installation: Installation | undefined;
+
+const getInstallation = (): Installation =>
+  (installation ??= resolveInstallation());
+
+function resolveInstallation(): Installation {
+  const dir = env.LARA_HOME ?? join(homedir(), ".lara");
+  const file = join(dir, INSTALLATION_FILE);
+
+  let stored: string | undefined;
+  try {
+    stored = readFileSync(file, "utf8").trim();
+  } catch {
+    // Missing or unreadable: fall through and write a fresh one.
+  }
+  if (stored && UUID_PATTERN.test(stored)) return { id: stored, created: false };
+
+  const id = randomUUID();
+  try {
+    mkdirSync(dir, { recursive: true });
+    // `wx` fails if the file appeared meanwhile, which settles the race between two processes
+    // starting together without a lock — the same job Redis SET NX does on the private server.
+    // A file that exists but holds something unusable is overwritten instead.
+    writeFileSync(file, id, { flag: stored === undefined ? "wx" : "w" });
+    return { id, created: stored === undefined };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "EEXIST") {
+      try {
+        const winner = readFileSync(file, "utf8").trim();
+        if (UUID_PATTERN.test(winner)) return { id: winner, created: false };
+      } catch {
+        // Unreadable right after it was created: fall through to the in-memory id.
+      }
+    }
+
+    // No writable home (a read-only container, no HOME): keep going with a per-process id rather
+    // than dropping telemetry. The cost is that this installation's rate limits do not carry
+    // across restarts.
+    logger.debug(
+      { error },
+      "Could not persist the metrics installation id, using a per-process one"
+    );
+    return { id, created: false };
+  }
+}
+
+/**
+ * The ingestion endpoints do not accept the API key: it buys a short-lived token, which is held in
+ * memory only — never logged, never written to disk.
+ */
+let token: string | undefined;
+let tokenExpiresAt = 0;
+let tokenRetryAfter = 0;
+
+async function getToken(): Promise<string> {
+  if (token && Date.now() < tokenExpiresAt) return token;
+
+  // The endpoint issues one token per 10s per installation. Asking again inside that window is
+  // guaranteed to 429, so the attempt is skipped and the batch rides the next flush. The window
+  // reopens as soon as an issuance succeeds.
+  if (Date.now() < tokenRetryAfter) throw new Error("issue-token is in cooldown");
+  tokenRetryAfter = Date.now() + TOKEN_COOLDOWN_MS;
+
+  const installationId = getInstallation().id;
+  const response = await postJson(TOKEN_URL, API_KEY, { installationId });
+  if (!response.ok) throw new Error(`issue-token returned ${response.status}`);
+
+  const body = (await response.json()) as { token?: string; expiresIn?: number };
+  if (!body.token) throw new Error("issue-token returned no token");
+
+  token = body.token;
+  tokenExpiresAt = Date.now() + (body.expiresIn ?? 3600) * 1000 - TOKEN_MARGIN_MS;
+  tokenRetryAfter = 0;
+  return token;
+}
+
+const queue: QueuedEvent[] = [];
+let flushTimer: ReturnType<typeof setTimeout> | undefined;
+let flushing: Promise<void> | undefined;
+
+/**
+ * Fire-and-forget event report. Never awaited, never throws: if the monitoring backend is down
+ * the MCP keeps translating as though nothing happened.
+ *
+ * Events are batched rather than posted one by one because the ingest quota counts requests
+ * (100/min per installation) far more tightly than events (20 000/min).
+ */
+export function logEvent(event: MetricsEvent): void {
+  if (!metricsEnabled()) return;
+
+  // Stamped on the way in, not at flush time: the timestamp is when the thing happened, and a
+  // delivery retry has to carry the same eventId to be recognizable as a duplicate.
+  queue.push({ ...ENVELOPE, eventId: randomUUID(), timestamp: new Date().toISOString(), ...event });
+  if (queue.length > MAX_QUEUE) queue.splice(0, queue.length - MAX_QUEUE);
+
+  if (!flushTimer) {
+    flushTimer = setTimeout(() => {
+      flushTimer = undefined;
+      void flushNow();
+    }, FLUSH_INTERVAL_MS);
+    // Without unref an idle server would be held open by the metrics timer alone.
+    flushTimer.unref();
+  }
+}
+
+/**
+ * Deliver whatever is queued. Awaited only on shutdown — otherwise the last batch dies with the
+ * process. Flushes are serialized so two of them can never race for the same token.
+ */
+export function flushNow(): Promise<void> {
+  flushing = (flushing ?? Promise.resolve()).then(drainQueue);
+  return flushing;
+}
+
+async function drainQueue(): Promise<void> {
+  while (queue.length > 0) {
+    const batch = queue.splice(0, MAX_BATCH);
+    try {
+      await sendBatch(batch);
+    } catch (error) {
+      // Never delivered — no token, or the request itself failed — so the batch goes back at the
+      // front and rides the next flush. A batch the backend answered with a verdict is a different
+      // thing and is dropped in sendBatch. MAX_QUEUE is what bounds a backend that stays down.
+      logger.debug({ error, events: batch.length }, "Metrics batch delivery failed, requeued");
+      // Overshoots MAX_QUEUE by at most one batch, which the next logEvent trims.
+      queue.unshift(...batch);
+      return;
+    }
+  }
+}
+
+async function sendBatch(events: QueuedEvent[]): Promise<void> {
+  let response = await postJson(INGEST_URL, await getToken(), { events });
+
+  // One retry, and only for an expired token. Anything else is either our problem or a
+  // misconfiguration, and looping on it helps nobody.
+  if (response.status === 401) {
+    token = undefined;
+    response = await postJson(INGEST_URL, await getToken(), { events });
+  }
+  if (response.ok) return;
+
+  // 429 and 5xx say "not now", not "not ever": throwing puts the batch back on the queue.
+  if (response.status === 429 || response.status >= 500) {
+    throw new Error(`ingest returned ${response.status}`);
+  }
+
+  logger.debug({ status: response.status, events: events.length }, "Metrics batch rejected");
+}
+
+const asId = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+/**
+ * The Lara account (`acc_...`) a Lara access token belongs to. Credits are consumed per account,
+ * so it is the granularity the funnel shares with every other channel: the access key is not an
+ * identity, it belongs to an account and is shared by its users.
+ *
+ * The payload is read without verifying the signature or `exp`: authorization already happened at
+ * the Lara API itself, here we only need an identifier out of our own credential.
+ */
+export function accountIdFromToken(token: string): string | undefined {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return undefined;
+
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    return asId(decoded?.id);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Short stable token for dashboards — free text would make grouping useless. The vocabulary is the
+ * one shared by every Lara integration, so the same failure reads the same way across channels.
+ */
+export function errorTypeFor(error: unknown): string {
+  if (error instanceof LaraApiError) {
+    const status = error.statusCode;
+    if (status === 401 || status === 403) return `auth_${status}`;
+    if (status === 429) return "rate_limit_429";
+    if (status === 413) return "payload_too_large";
+    if (status >= 500) return "server_error";
+    if (error.type === "AuthenticationError") return "auth_401";
+    // Every other 4xx from Lara is a request we built wrong.
+    if (status >= 400) return "validation_error";
+    return "unknown";
+  }
+
+  if (error instanceof TimeoutError) return "timeout";
+  // A ZodError is what a tool's argument parse throws, and it reaches here
+  // before CallTool has rewritten it into an InvalidInputError.
+  if (error instanceof z.ZodError) return "validation_error";
+  if (error instanceof InvalidInputError) return "validation_error";
+
+  const code = (error as { code?: unknown } | null)?.code;
+  const name = (error as { name?: unknown } | null)?.name;
+  if (code === "ETIMEDOUT" || name === "AbortError" || name === "TimeoutError") return "timeout";
+  if (code === "ECONNREFUSED" || code === "ENOTFOUND" || code === "ECONNRESET")
+    return "network_error";
+
+  return "unknown";
+}
+
+/** A credential Lara rejected, which is what separates auth_fail from any other call_error. */
+const isAuthError = (error: unknown): boolean =>
+  error instanceof LaraApiError &&
+  (error.statusCode === 401 ||
+    error.statusCode === 403 ||
+    error.type === "AuthenticationError");
+
+/**
+ * Everything one MCP session needs to report against. The account is not known when the session is
+ * built: an access key is not an account, and the SDK only exchanges it for a Lara token lazily, on
+ * the first request — so it is resolved after a call has succeeded and cached here.
+ */
+export type MetricsContext = {
+  accountId?: string;
+  translator: Translator;
+};
+
+/** Undefined when telemetry is off, which makes every report below a no-op. */
+export function createMetricsContext(
+  translator: Translator
+): MetricsContext | undefined {
+  return metricsEnabled() ? { translator } : undefined;
+}
+
+/**
+ * The Lara account this session's events are attributed to.
+ *
+ * No token, no account, no event: an access key that `/v2/auth` rejected never produces one, so
+ * the `auth_fail` for a bad key is lost. That is the right trade — a made-up id is a fake account
+ * that pollutes every number in the funnel.
+ */
+function accountIdFor(ctx: MetricsContext): string | undefined {
+  if (ctx.accountId) return ctx.accountId;
+
+  const laraToken = getLaraClient(ctx.translator)?.token;
+  ctx.accountId = laraToken ? accountIdFromToken(laraToken) : undefined;
+  return ctx.accountId;
+}
+
+/**
+ * Access-key credentials are never validated on their own, so the first call that comes back OK is
+ * the proof they work. Deduplicated per account rather than per session because the HTTP transport
+ * is stateless — it builds a fresh Translator per request, which would otherwise report an
+ * auth_success on every tool call.
+ */
+const seenAccounts = new Set<string>();
+
+function reportAuthSuccessOnce(accountId: string): void {
+  if (seenAccounts.has(accountId)) return;
+  if (seenAccounts.size >= MAX_SEEN_ACCOUNTS) seenAccounts.clear();
+  seenAccounts.add(accountId);
+
+  logEvent({ eventType: "auth_success", accountId, metadata: { ...BASE_METADATA } });
+}
+
+/**
+ * Report a tool call that returned. Called from inside CallTool rather than from a wrapper around
+ * it, because CallTool rewrites the SDK's errors before they escape and the error path below needs
+ * the original.
+ */
+export function reportCallSuccess(
+  ctx: MetricsContext | undefined,
+  toolName: string,
+  args: unknown,
+  startedAt: number
+): void {
+  if (!ctx) return;
+
+  const accountId = accountIdFor(ctx);
+  if (!accountId) return;
+
+  reportAuthSuccessOnce(accountId);
+
+  const call = callFieldsFor(toolName, args);
+  logEvent({
+    eventType: "call_success",
+    accountId,
+    latencyMs: Date.now() - startedAt,
+    charsTranslated: call.charsTranslated,
+    metadata: call.metadata,
+  });
+}
+
+/** Report a tool call that threw. The error itself is never altered, only described. */
+export function reportCallError(
+  ctx: MetricsContext | undefined,
+  toolName: string,
+  args: unknown,
+  startedAt: number,
+  error: unknown
+): void {
+  if (!ctx) return;
+
+  const accountId = accountIdFor(ctx);
+  if (!accountId) return;
+
+  const { metadata } = callFieldsFor(toolName, args);
+  const errorType = errorTypeFor(error);
+  const latencyMs = Date.now() - startedAt;
+
+  logEvent({ eventType: "call_error", accountId, errorType, latencyMs, metadata });
+  if (isAuthError(error)) {
+    logEvent({ eventType: "auth_fail", accountId, errorType, metadata });
+  }
+}
+
+// The one event that is not about a request: this copy of the server had no installation id, so
+// this is the first time it has ever run. It carries no accountId — no key has been accepted yet —
+// which is one of the two cases the backend allows that on.
+if (metricsEnabled() && getInstallation().created) {
+  logEvent({ eventType: "install", metadata: { ...BASE_METADATA } });
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -271,6 +271,11 @@ const queue: QueuedEvent[] = [];
 let flushTimer: ReturnType<typeof setTimeout> | undefined;
 let flushing: Promise<void> | undefined;
 
+/** Drops the oldest events once the backlog is past its bound. */
+function trimQueue(): void {
+  if (queue.length > MAX_QUEUE) queue.splice(0, queue.length - MAX_QUEUE);
+}
+
 /**
  * Fire-and-forget event report. Never awaited, never throws: if the monitoring backend is down
  * the MCP keeps translating as though nothing happened.
@@ -281,10 +286,12 @@ let flushing: Promise<void> | undefined;
 export function logEvent(event: MetricsEvent): void {
   if (!metricsEnabled()) return;
 
-  // Stamped on the way in, not at flush time: the timestamp is when the thing happened, and a
-  // delivery retry has to carry the same eventId to be recognizable as a duplicate.
-  queue.push({ ...ENVELOPE, eventId: randomUUID(), timestamp: new Date().toISOString(), ...event });
-  if (queue.length > MAX_QUEUE) queue.splice(0, queue.length - MAX_QUEUE);
+  // The envelope is stamped last so it always wins: channel and sessionId are facts about this
+  // process, never something a caller supplies. Both are stamped on the way in rather than at
+  // flush time — the timestamp is when the thing happened, and a delivery retry has to carry the
+  // same eventId to be recognizable as a duplicate.
+  queue.push({ ...event, ...ENVELOPE, eventId: randomUUID(), timestamp: new Date().toISOString() });
+  trimQueue();
 
   if (!flushTimer) {
     flushTimer = setTimeout(() => {
@@ -315,8 +322,10 @@ async function drainQueue(): Promise<void> {
       // front and rides the next flush. A batch the backend answered with a verdict is a different
       // thing and is dropped in sendBatch. MAX_QUEUE is what bounds a backend that stays down.
       logger.debug({ error, events: batch.length }, "Metrics batch delivery failed, requeued");
-      // Overshoots MAX_QUEUE by at most one batch, which the next logEvent trims.
       queue.unshift(...batch);
+      // Bounded here rather than left to the next logEvent: a server that goes idle while the
+      // backend is down would otherwise sit above the cap indefinitely.
+      trimQueue();
       return;
     }
   }


### PR DESCRIPTION
Reports funnel metrics to the integrations monitoring backend on channel `mcp`, so the gap between installs and actual usage can be measured. Both transports report — unlike the private server, which is HTTP-only because its installation id lives in Redis.

Follows the shared event reporting standard (`src/modules/metrics/frontend.md` in `lara-integrations-monitoring`).

## Events

| Event | When |
| --- | --- |
| `install` | first run only, when the installation id is created. No `accountId` |
| `auth_success` | first call that comes back OK — access key credentials are never validated on their own |
| `auth_fail` | beside a `call_error` Lara answered with 401/403 |
| `call_success` / `call_error` | every tool call, with `latencyMs` and `charsTranslated` |

`auth_success` is deduplicated per account per process: the HTTP transport is stateless and builds a `Translator` per request, which would otherwise report one on every tool call.

## What is sent

`accountId` is the Lara account (`acc_...`) behind the credentials, read from the `id` claim of the token the SDK holds. An access key is not an account — it belongs to one and is shared by its users — so reporting it would split the same customer across channels. No token means no account and **no event**: a made-up id is a fake account in every dashboard, which is why a rejected key produces no `auth_fail`.

`metadata` carries `feature` (`text` / `language_detection` / `resource_management`), `toolName`, `transport`, and the language tags on `translate`. Never the translated text, never a credential.

## Delivery

Buys a token from `/auth/issue-token` with the channel API key, posts to `/metrics/ingest-events`. Batched every 2s behind an `unref`'d timer, one retry on 401 only, requeued on 429/5xx, dropped on any other rejection, queue capped at 10 000, flushed once on shutdown with a 2s cap.

A backend that is down never delays, alters or fails a translation.

## Opt-out

`DO_NOT_TRACK` set to `1`/`true`/`yes` and nothing is measured, queued, written to disk or sent. Documented in the README.

The installation id is a random UUID at `${LARA_HOME:-~/.lara}/installation-id`, tied to nothing; it exists so repeated runs of the same install count as one. An unwritable home falls back to a per-process id rather than dropping telemetry.

## Before this can ship

`DEFAULT_METRICS_URL` and `DEFAULT_METRICS_API_KEY` in `src/metrics.ts` are **empty**, so telemetry is off for everyone as it stands. They need the deployed backend hostname and a production key issued for the `mcp` channel — the monitoring backend has no deployment yet, and only ships a development key. `METRICS_URL` / `METRICS_API_KEY` override them meanwhile.

Note the key is compiled into a public npm package and will be readable by anyone who installs it. It is write-only, but worth a deliberate decision before filling it in.

## Notes

Events are emitted inside `CallTool`'s own try/catch rather than from a wrapper around it: `CallTool` rewrites `LaraApiError` into `InvalidInputError` before it escapes, so only there is the original error still available to classify. A wrapper would have seen every failure as `validation_error` and `auth_fail` would never have fired.

The cast through the SDK's `protected client` moved into `src/lara-client.ts`, reused by the existing `X-Lara-Client` headers, so an SDK shape change surfaces in one place.

## Testing

60 new tests (226 total, all green): the client in isolation — queue, batching, token cooldown, 401 retry, installation id races, opt-out, payload never carrying credentials or text — and the server wiring end to end.

Verified against a local monitoring backend with real Lara credentials, both transports, reading the rows back out of ClickHouse:

- stdio: `install` → `auth_success` → three `call_success` with the right account, `charsTranslated: 19` on a translate whose `translatable: false` block was correctly excluded
- http: one `auth_success` across two stateless requests, then `auth_fail` + `call_error` on a revoked key
- wrong secret → no events at all
- `DO_NOT_TRACK=1`, unconfigured defaults, malformed `METRICS_URL`, unreachable backend → server behaves exactly as before, `~/.lara` never created
